### PR TITLE
Align with AKO 1.6.1 template and minor enhancement 

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -139,6 +139,16 @@ type ExtraConfigs struct {
 	// +optional
 	ServicesAPI *bool `json:"servicesAPI,omitempty"`
 
+	// This flag indicates to AKO that it should listen on Istio resources.
+	// default value is false
+	// +optional
+	IstioEnabled *bool `json:"istioEnabled,omitempty"`
+
+	// Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
+	// default value is false
+	// +optional
+	VIPPerNamespace *bool `json:"vipPerNamespace,omitempty"`
+
 	// NetworksConfig specifies the network configurations for virtual services.
 	// +optional
 	NetworksConfig NetworksConfig `json:"networksConfig,omitempty"`
@@ -175,6 +185,10 @@ type NetworksConfig struct {
 	// BGPPeerLabels specifies BGP peers, this is used for selective VsVip advertisement.
 	// +optional
 	BGPPeerLabels []string `json:"bgpPeerLabels,omitempty"`
+
+	// T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
+	// +optional
+	NsxtT1LR string `json:"nsxtT1LR,omitempty"`
 
 	// VipNetworkList specifies Network information of the VIP network.
 	// Multiple networks allowed only for AWS Cloud.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -269,6 +269,16 @@ func (in *ExtraConfigs) DeepCopyInto(out *ExtraConfigs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IstioEnabled != nil {
+		in, out := &in.IstioEnabled, &out.IstioEnabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.VIPPerNamespace != nil {
+		in, out := &in.VIPPerNamespace, &out.VIPPerNamespace
+		*out = new(bool)
+		**out = **in
+	}
 	in.NetworksConfig.DeepCopyInto(&out.NetworksConfig)
 	in.IngressConfigs.DeepCopyInto(&out.IngressConfigs)
 	in.L4Configs.DeepCopyInto(&out.L4Configs)

--- a/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
+++ b/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
@@ -202,6 +202,9 @@ spec:
                         - DEDICATED
                         type: string
                     type: object
+                  istioEnabled:
+                    description: This flag indicates to AKO that it should listen on Istio resources. default value is false
+                    type: boolean
                   l4Config:
                     description: IngressConfigs specifies L4 load balancer configuration for ako
                     properties:
@@ -262,6 +265,9 @@ spec:
                       enableRHI:
                         description: EnableRHI specifies cluster wide setting for BGP peering. default value is false
                         type: boolean
+                      nsxtT1LR:
+                        description: T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
+                        type: string
                     type: object
                   nodePortSelector:
                     description: NodePortSelector only applicable if serviceType is NodePort
@@ -283,6 +289,9 @@ spec:
                     type: object
                   servicesAPI:
                     description: 'ServicesAPI specifies if enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently, implemented only for L4. This flag uses the upstream GA APIs which are not backward compatible with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 default value is false'
+                    type: boolean
+                  vipPerNamespace:
+                    description: Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode default value is false
                     type: boolean
                 type: object
               serviceEngineGroup:

--- a/config/samples/network_v1alpha1_akodeploymentconfig.yaml
+++ b/config/samples/network_v1alpha1_akodeploymentconfig.yaml
@@ -26,6 +26,8 @@ spec:
         disableStaticRouteSync: true
         enableEVH: false
         layer7Only: false
+        istioEnabled: false
+        vipPerNamespace: false
         l4Config:
             advancedL4: false
             autoFQDN: "disabled"
@@ -45,6 +47,7 @@ spec:
             logLevel: "INFO"
         networksConfig:
             enableRHI: false
+            nsxtT1LR: "NSX-T-T1-ROUTER-ID"
 ---
 apiVersion: v1
 kind: Secret

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -202,6 +202,9 @@ spec:
                         - DEDICATED
                         type: string
                     type: object
+                  istioEnabled:
+                    description: This flag indicates to AKO that it should listen on Istio resources. default value is false
+                    type: boolean
                   l4Config:
                     description: IngressConfigs specifies L4 load balancer configuration for ako
                     properties:
@@ -262,6 +265,9 @@ spec:
                       enableRHI:
                         description: EnableRHI specifies cluster wide setting for BGP peering. default value is false
                         type: boolean
+                      nsxtT1LR:
+                        description: T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
+                        type: string
                     type: object
                   nodePortSelector:
                     description: NodePortSelector only applicable if serviceType is NodePort
@@ -283,6 +289,9 @@ spec:
                     type: object
                   servicesAPI:
                     description: 'ServicesAPI specifies if enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently, implemented only for L4. This flag uses the upstream GA APIs which are not backward compatible with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 default value is false'
+                    type: boolean
+                  vipPerNamespace:
+                    description: Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode default value is false
                     type: boolean
                 type: object
               serviceEngineGroup:

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -6,6 +6,7 @@ package akodeploymentconfig
 import (
 	"bytes"
 	"context"
+	"github.com/pkg/errors"
 	"net"
 	"sort"
 	"time"
@@ -151,7 +152,7 @@ func (r *AKODeploymentConfigReconciler) reconcileNetworkSubnets(
 
 	network, err := r.aviClient.NetworkGetByName(obj.Spec.DataNetwork.Name)
 	if err != nil {
-		log.Error(err, "Failed to get the Data Network from AVI Controller")
+		log.Info("[WARN] Failed to get the Data Network from AVI Controller")
 		return res, nil
 	}
 
@@ -204,7 +205,7 @@ func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
 
 	network, err := r.aviClient.NetworkGetByName(obj.Spec.DataNetwork.Name)
 	if err != nil {
-		log.Error(err, "Failed to get the Data Network from AVI Controller")
+		log.Error(errors.Errorf("[WARN]Failed to get the Data Network %s from AVI Controller", obj.Spec.DataNetwork.Name),"")
 		return requeueAfter, nil
 	}
 

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -36,6 +36,8 @@ loadBalancerAndIngressService:
             enable_EVH: ""
             layer_7_only: ""
             services_api: ""
+            istio_enabled: ""
+            vip_per_namespace: ""
             namespace_selector:
                 label_key: ""
                 label_value: ""
@@ -46,6 +48,7 @@ loadBalancerAndIngressService:
             node_network_list: '[{"networkName":"test-node-network-1","cidrs":["10.0.0.0/24","192.168.0.0/24"]}]'
             vip_network_list: '[{"networkName":"test-akdc"}]'
             enable_rhi: ""
+            nsxt_t1_lr: ""
             bgp_peer_labels: ""
         l7_settings:
             disable_ingress_class: true
@@ -174,16 +177,6 @@ func unitTestAKODeploymentYaml() {
 				_, err := cluster.AkoAddonSecretDataYaml(capicluster, akoDeploymentConfig, aviUserSecret)
 				Expect(err).Should(HaveOccurred())
 				akoDeploymentConfig.Spec.DataNetwork.CIDR = "10.0.0.0/24"
-			})
-
-			It("should expose a bug that we cannot update delete_config in this way", func() {
-				values, err := ako.NewValues(akoDeploymentConfig, "namespace-name")
-				Expect(err).ShouldNot(HaveOccurred())
-				akoSetting := values.LoadBalancerAndIngressService.Config.AKOSettings
-				akoSetting.DeleteConfig = "true"
-				secretData, err := values.YttYaml()
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(secretData).Should(ContainSubstring("delete_config: \"false\""))
 			})
 
 			It("should update delete_config in this way", func() {

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -99,20 +99,20 @@ type LoadBalancerAndIngressService struct {
 // Config consists of different configurations for Values that includes settings of
 // AKO, networking, L4, L7, Rbac etc
 type Config struct {
-	IsClusterService      string             `yaml:"is_cluster_service"`
-	ReplicaCount          int                `yaml:"replica_count"`
-	AKOSettings           AKOSettings        `yaml:"ako_settings"`
-	NetworkSettings       NetworkSettings    `yaml:"network_settings"`
-	L7Settings            L7Settings         `yaml:"l7_settings"`
-	L4Settings            L4Settings         `yaml:"l4_settings"`
-	ControllerSettings    ControllerSettings `yaml:"controller_settings"`
-	NodePortSelector      NodePortSelector   `yaml:"nodeport_selector"`
-	Resources             Resources          `yaml:"resources"`
-	Rbac                  Rbac               `yaml:"rbac"`
-	PersistentVolumeClaim string             `yaml:"persistent_volume_claim"`
-	MountPath             string             `yaml:"mount_path"`
-	LogFile               string             `yaml:"log_file"`
-	Avicredentials        Avicredentials     `yaml:"avi_credentials"`
+	IsClusterService      string              `yaml:"is_cluster_service"`
+	ReplicaCount          int                 `yaml:"replica_count"`
+	AKOSettings           *AKOSettings        `yaml:"ako_settings"`
+	NetworkSettings       *NetworkSettings    `yaml:"network_settings"`
+	L7Settings            *L7Settings         `yaml:"l7_settings"`
+	L4Settings            *L4Settings         `yaml:"l4_settings"`
+	ControllerSettings    *ControllerSettings `yaml:"controller_settings"`
+	NodePortSelector      *NodePortSelector   `yaml:"nodeport_selector"`
+	Resources             *Resources          `yaml:"resources"`
+	Rbac                  *Rbac               `yaml:"rbac"`
+	PersistentVolumeClaim string              `yaml:"persistent_volume_claim"`
+	MountPath             string              `yaml:"mount_path"`
+	LogFile               string              `yaml:"log_file"`
+	Avicredentials        Avicredentials      `yaml:"avi_credentials"`
 }
 
 // NamespaceSelector contains label key and value used for namespace migration.
@@ -135,12 +135,14 @@ type AKOSettings struct {
 	EnableEVH              string            `yaml:"enable_EVH"`   // This enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services
 	Layer7Only             string            `yaml:"layer_7_only"` // If this flag is switched on, then AKO will only do layer 7 loadbalancing
 	ServicesAPI            string            `yaml:"services_api"` // Flag that enables AKO in services API mode. Currently implemented only for L4.
+	IstioEnabled           string            `yaml:"istio_enabled"`
+	VIPPerNamespace        string            `yaml:"vip_per_namespace"`
 	NamespaceSector        NamespaceSelector `yaml:"namespace_selector"`
 }
 
 // DefaultAKOSettings returns the default AKOSettings
-func DefaultAKOSettings() AKOSettings {
-	return AKOSettings{
+func DefaultAKOSettings() *AKOSettings {
+	return &AKOSettings{
 		LogLevel:               "INFO",
 		ApiServerPort:          8080,
 		DeleteConfig:           "false",
@@ -154,7 +156,7 @@ func DefaultAKOSettings() AKOSettings {
 
 // NewAKOSettings returns a new AKOSettings,
 // allow users to set CniPlugin, ClusterName and DisableStaticRouteSync in runtime
-func NewAKOSettings(clusterName string, obj *akoov1alpha1.AKODeploymentConfig) (settings AKOSettings) {
+func NewAKOSettings(clusterName string, obj *akoov1alpha1.AKODeploymentConfig) (settings *AKOSettings) {
 	settings = DefaultAKOSettings()
 	settings.ClusterName = clusterName
 	if obj.Spec.ExtraConfigs.Log.LogLevel != "" {
@@ -181,6 +183,12 @@ func NewAKOSettings(clusterName string, obj *akoov1alpha1.AKODeploymentConfig) (
 	if obj.Spec.ExtraConfigs.ServicesAPI != nil {
 		settings.ServicesAPI = strconv.FormatBool(*obj.Spec.ExtraConfigs.ServicesAPI)
 	}
+	if obj.Spec.ExtraConfigs.IstioEnabled != nil {
+		settings.IstioEnabled = strconv.FormatBool(*obj.Spec.ExtraConfigs.IstioEnabled)
+	}
+	if obj.Spec.ExtraConfigs.VIPPerNamespace != nil {
+		settings.VIPPerNamespace = strconv.FormatBool(*obj.Spec.ExtraConfigs.VIPPerNamespace)
+	}
 	if obj.Spec.ExtraConfigs.NamespaceSelector.LabelKey != "" {
 		settings.NamespaceSector.LabelKey = obj.Spec.ExtraConfigs.NamespaceSelector.LabelKey
 	}
@@ -200,13 +208,14 @@ type NetworkSettings struct {
 	VIPNetworkList      []map[string]string    `yaml:"-"` // Network information of the VIP network. Multiple networks allowed only for AWS Cloud.
 	VIPNetworkListJson  string                 `yaml:"vip_network_list"`
 	EnableRHI           string                 `yaml:"enable_rhi"` // This is a cluster wide setting for BGP peering.
-	BGPPeerLabels       []string               `yaml:"-"`          // Select BGP peers using bgpPeerLabels, for selective VsVip advertisement.
+	NsxtT1LR            string                 `yaml:"nsxt_t1_lr"`
+	BGPPeerLabels       []string               `yaml:"-"` // Select BGP peers using bgpPeerLabels, for selective VsVip advertisement.
 	BGPPeerLabelsJson   string                 `yaml:"bgp_peer_labels"`
 }
 
 // DefaultNetworkSettings returns default NetworkSettings
-func DefaultNetworkSettings() NetworkSettings {
-	return NetworkSettings{
+func DefaultNetworkSettings() *NetworkSettings {
+	return &NetworkSettings{
 		// SubnetIP: don't set, populate in runtime
 		// SubnetPrefix: don't set, populate in runtime
 		// NetworkName: don't set, populate in runtime
@@ -217,12 +226,12 @@ func DefaultNetworkSettings() NetworkSettings {
 
 // NewNetworkSettings returns a new NetworkSettings
 // allow user to set NetworkName, SubnetIP, SubnetPrefix, NodeNetworkList and VIPNetworkList at runtime
-func NewNetworkSettings(obj *akoov1alpha1.AKODeploymentConfig) (NetworkSettings, error) {
+func NewNetworkSettings(obj *akoov1alpha1.AKODeploymentConfig) (*NetworkSettings, error) {
 	settings := DefaultNetworkSettings()
 	settings.NetworkName = obj.Spec.DataNetwork.Name
 	ip, ipNet, err := net.ParseCIDR(obj.Spec.DataNetwork.CIDR)
 	if err != nil {
-		return NetworkSettings{}, err
+		return &NetworkSettings{}, err
 	}
 	settings.SubnetIP = ip.String()
 	ones, _ := ipNet.Mask.Size()
@@ -234,25 +243,26 @@ func NewNetworkSettings(obj *akoov1alpha1.AKODeploymentConfig) (NetworkSettings,
 	if len(settings.NodeNetworkList) != 0 {
 		jsonBytes, err := json.Marshal(settings.NodeNetworkList)
 		if err != nil {
-			return NetworkSettings{}, err
+			return &NetworkSettings{}, err
 		}
 		settings.NodeNetworkListJson = string(jsonBytes)
 	}
 	if len(settings.VIPNetworkList) != 0 {
 		jsonBytes, err := json.Marshal(settings.VIPNetworkList)
 		if err != nil {
-			return NetworkSettings{}, err
+			return &NetworkSettings{}, err
 		}
 		settings.VIPNetworkListJson = string(jsonBytes)
 	}
 	if obj.Spec.ExtraConfigs.NetworksConfig.EnableRHI != nil {
 		settings.EnableRHI = strconv.FormatBool(*obj.Spec.ExtraConfigs.NetworksConfig.EnableRHI)
 	}
+	settings.NsxtT1LR = obj.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR
 	settings.BGPPeerLabels = obj.Spec.ExtraConfigs.NetworksConfig.BGPPeerLabels
 	if len(settings.BGPPeerLabels) != 0 {
 		jsonBytes, err := json.Marshal(settings.BGPPeerLabels)
 		if err != nil {
-			return NetworkSettings{}, err
+			return &NetworkSettings{}, err
 		}
 		settings.BGPPeerLabelsJson = string(jsonBytes)
 	}
@@ -271,8 +281,8 @@ type L7Settings struct {
 }
 
 // DefaultL7Settings returns the default L7Settings
-func DefaultL7Settings() L7Settings {
-	return L7Settings{
+func DefaultL7Settings() *L7Settings {
+	return &L7Settings{
 		DefaultIngController: false,
 		ServiceType:          "NodePort",
 		ShardVSSize:          "SMALL",
@@ -283,7 +293,7 @@ func DefaultL7Settings() L7Settings {
 
 // NewL7Settings returns a customized L7Settings after parsing the v1alpha1.AKOIngressConfig
 // it only modifies ServiceType and ShardVSSize when instructed by the ingressConfig
-func NewL7Settings(config *akoov1alpha1.AKOIngressConfig) L7Settings {
+func NewL7Settings(config *akoov1alpha1.AKOIngressConfig) *L7Settings {
 	settings := DefaultL7Settings()
 	settings.DisableIngressClass = config.DisableIngressClass
 	settings.DefaultIngController = config.DefaultIngressController
@@ -310,14 +320,14 @@ type L4Settings struct {
 }
 
 // DefaultL4Settings returns the default L4Settings
-func DefaultL4Settings() L4Settings {
-	return L4Settings{
+func DefaultL4Settings() *L4Settings {
+	return &L4Settings{
 		// DefaultDomain: don't set, use default value in AKO
 	}
 }
 
 // NewL4Settings returns a customized L4Settings after parsing the v1alpha1.AKOL4Config
-func NewL4Settings(config *akoov1alpha1.AKOL4Config) L4Settings {
+func NewL4Settings(config *akoov1alpha1.AKOL4Config) *L4Settings {
 	settings := DefaultL4Settings()
 	if config.AdvancedL4 != nil {
 		settings.AdvancedL4 = strconv.FormatBool(*config.AdvancedL4)
@@ -340,8 +350,8 @@ type ControllerSettings struct {
 }
 
 // DefaultControllerSettings return the default ControllerSettings
-func DefaultControllerSettings() ControllerSettings {
-	return ControllerSettings{
+func DefaultControllerSettings() *ControllerSettings {
+	return &ControllerSettings{
 		// ServiceEngineGroupName: populate in runtime
 		// CloudName: populate in runtime
 		// ControllerIP: populate in runtime
@@ -352,7 +362,7 @@ func DefaultControllerSettings() ControllerSettings {
 
 // NewControllerSettings returns a ControllerSettings from default,
 // allow setting CloudName, ControllerIP and ServiceEngineGroupName
-func NewControllerSettings(cloudName, controllerIP, serviceEngineGroup string) (setting ControllerSettings) {
+func NewControllerSettings(cloudName, controllerIP, serviceEngineGroup string) (setting *ControllerSettings) {
 	setting = DefaultControllerSettings()
 	setting.CloudName = cloudName
 	setting.ControllerIP = controllerIP
@@ -367,15 +377,15 @@ type NodePortSelector struct {
 }
 
 // DefaultNodePortSelector returns the default NodePortSelector
-func DefaultNodePortSelector() NodePortSelector {
-	return NodePortSelector{
+func DefaultNodePortSelector() *NodePortSelector {
+	return &NodePortSelector{
 		// Key: don't set, use default value in AKO
 		// Value: don't set, use default value in AKO
 	}
 }
 
 // NewNodePortSelector returns the NodePortSelector defined in AKODeploymentConfig
-func NewNodePortSelector(nodePortSelector *akoov1alpha1.NodePortSelector) NodePortSelector {
+func NewNodePortSelector(nodePortSelector *akoov1alpha1.NodePortSelector) *NodePortSelector {
 	selector := DefaultNodePortSelector()
 	if nodePortSelector.Key != "" {
 		selector.Key = nodePortSelector.Key
@@ -392,8 +402,8 @@ type Resources struct {
 }
 
 // DefaultResources returns the default configuration for Resources
-func DefaultResources() Resources {
-	return Resources{
+func DefaultResources() *Resources {
+	return &Resources{
 		Limits: Limits{
 			Cpu:    "250m",
 			Memory: "300Mi",
@@ -422,8 +432,8 @@ type Rbac struct {
 }
 
 // NewRbac creates a Rbac from the v1alpha1.AKORbacConfig
-func NewRbac(config v1alpha1.AKORbacConfig) Rbac {
-	return Rbac{
+func NewRbac(config v1alpha1.AKORbacConfig) *Rbac {
+	return &Rbac{
 		PspEnabled:          config.PspEnabled,
 		PspPolicyApiVersion: config.PspPolicyAPIVersion,
 	}


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:
This PR:
- Aligns with AKO 1.6.1 templates.
- Fixes value-pass problem
- Fixes polluted & meaningless logs 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.



/config