### PR TITLE
make avi controller version configurable

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -26,6 +26,10 @@ type AKODeploymentConfigSpec struct {
 	//                              the corresponding scheme
 	Controller string `json:"controller"`
 
+	// ControllerVersion is the AVI Controller version which AKO Operator and AKO talks to.
+	// If not set, default version is 20.1.3
+	ControllerVersion string `json:"controllerVersion,omitempty"`
+
 	// ServiceEngineGroup is the group name of Service Engine that's to be used by the set
 	// of AKO Deployments
 	ServiceEngineGroup string `json:"serviceEngineGroup"`

--- a/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
+++ b/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
@@ -96,6 +96,9 @@ spec:
               controller:
                 description: Controller is the AVI Controller endpoint to which AKO talks to provision Load Balancer resources The format is [scheme://]address[:port] * scheme                     http or https, defaults to https if not                              specified * address                    IP address of the AVI Controller                              specified * port                       if not specified, use default port for                              the corresponding scheme
                 type: string
+              controllerVersion:
+                description: ControllerVersion is the AVI Controller version which AKO Operator and AKO talks to. If not set, default version is 20.1.3
+                type: string
               dataNetwork:
                 description: DataNetworks describes the Data Networks the AKO will be deployed with. This field is immutable.
                 properties:

--- a/config/samples/network_v1alpha1_akodeploymentconfig.yaml
+++ b/config/samples/network_v1alpha1_akodeploymentconfig.yaml
@@ -6,6 +6,7 @@ spec:
     cloudName: Default-Cloud
     serviceEngineGroup: Default-Group
     controller: 10.161.150.145
+    controllerVersion: 20.1.6
     adminCredentialRef:
         name: avi-controller-credentials
         namespace: default

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -96,6 +96,9 @@ spec:
               controller:
                 description: Controller is the AVI Controller endpoint to which AKO talks to provision Load Balancer resources The format is [scheme://]address[:port] * scheme                     http or https, defaults to https if not                              specified * address                    IP address of the AVI Controller                              specified * port                       if not specified, use default port for                              the corresponding scheme
                 type: string
+              controllerVersion:
+                description: ControllerVersion is the AVI Controller version which AKO Operator and AKO talks to. If not set, default version is 20.1.3
+                type: string
               dataNetwork:
                 description: DataNetworks describes the Data Networks the AKO will be deployed with. This field is immutable.
                 properties:

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -6,10 +6,11 @@ package akodeploymentconfig
 import (
 	"bytes"
 	"context"
-	"github.com/pkg/errors"
 	"net"
 	"sort"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"gitlab.eng.vmware.com/core-build/ako-operator/controllers/akodeploymentconfig/phases"
 	"gitlab.eng.vmware.com/core-build/ako-operator/controllers/akodeploymentconfig/user"
@@ -22,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akoov1alpha1 "gitlab.eng.vmware.com/core-build/ako-operator/api/v1alpha1"
+	ako_operator "gitlab.eng.vmware.com/core-build/ako-operator/pkg/ako-operator"
 	"gitlab.eng.vmware.com/core-build/ako-operator/pkg/aviclient"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -65,7 +67,7 @@ func (r *AKODeploymentConfigReconciler) initAVI(
 			Username: string(adminCredential.Data["username"][:]),
 			Password: string(adminCredential.Data["password"][:]),
 			CA:       string(aviControllerCA.Data["certificateAuthorityData"][:]),
-		}, akoov1alpha1.AVI_VERSION)
+		}, ako_operator.GetAVIControllerVersion())
 		if err != nil {
 			log.Error(err, "Failed to initialize AVI Controller Client, requeue the request")
 			return res, err
@@ -205,7 +207,7 @@ func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
 
 	network, err := r.aviClient.NetworkGetByName(obj.Spec.DataNetwork.Name)
 	if err != nil {
-		log.Error(errors.Errorf("[WARN]Failed to get the Data Network %s from AVI Controller", obj.Spec.DataNetwork.Name),"")
+		log.Error(errors.Errorf("[WARN]Failed to get the Data Network %s from AVI Controller", obj.Spec.DataNetwork.Name), "")
 		return requeueAfter, nil
 	}
 

--- a/e2e/pkg/env/avi.go
+++ b/e2e/pkg/env/avi.go
@@ -8,7 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	akoov1alpha1 "gitlab.eng.vmware.com/core-build/ako-operator/api/v1alpha1"
+	ako_operator "gitlab.eng.vmware.com/core-build/ako-operator/pkg/ako-operator"
+
 	"gitlab.eng.vmware.com/core-build/ako-operator/pkg/aviclient"
 )
 
@@ -19,7 +20,7 @@ func NewAviRunner(runner *KubectlRunner) aviclient.Client {
 		Username: GetAviObject(runner, "secret", "controller-credentials", "data", "username"),
 		Password: GetAviObject(runner, "secret", "controller-credentials", "data", "password"),
 		CA:       GetAviObject(runner, "secret", "controller-ca", "data", "certificateAuthorityData"),
-	}, akoov1alpha1.AVI_VERSION)
+	}, ako_operator.GetAVIControllerVersion())
 
 	return aviClient
 }

--- a/pkg/ako-operator/config_envvar.go
+++ b/pkg/ako-operator/config_envvar.go
@@ -6,6 +6,8 @@ package ako_operator
 import (
 	"os"
 	"strconv"
+
+	akoov1alpha1 "gitlab.eng.vmware.com/core-build/ako-operator/api/v1alpha1"
 )
 
 // Environment variables
@@ -21,6 +23,9 @@ const (
 
 	// ControlPlaneEndpointPort - defines the control plane endpoint port
 	ControlPlaneEndpointPort = "control_plane_endpoint_port"
+
+	// AVIControllerVersion - defines the AVI controller version load balancer operator will talk to
+	AVIControllerVersion = "avi_controller_version"
 )
 
 func IsBootStrapCluster() bool {
@@ -37,4 +42,12 @@ func GetControlPlaneEndpointPort() int32 {
 		return 6443
 	}
 	return int32(port)
+}
+
+func GetAVIControllerVersion() string {
+	version, set := os.LookupEnv(AVIControllerVersion)
+	if set {
+		return version
+	}
+	return akoov1alpha1.AVI_VERSION
 }

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -37,6 +37,7 @@ func NewValues(obj *akoov1alpha1.AKODeploymentConfig, clusterNameSpacedName stri
 	controllerSettings := NewControllerSettings(
 		obj.Spec.CloudName,
 		obj.Spec.Controller,
+		obj.Spec.ControllerVersion,
 		obj.Spec.ServiceEngineGroup,
 	)
 	l7Settings := NewL7Settings(&obj.Spec.ExtraConfigs.IngressConfigs)
@@ -361,12 +362,15 @@ func DefaultControllerSettings() *ControllerSettings {
 }
 
 // NewControllerSettings returns a ControllerSettings from default,
-// allow setting CloudName, ControllerIP and ServiceEngineGroupName
-func NewControllerSettings(cloudName, controllerIP, serviceEngineGroup string) (setting *ControllerSettings) {
+// allow setting CloudName, ControllerIP, ControllerVersion and ServiceEngineGroupName
+func NewControllerSettings(cloudName, controllerIP, controllerVersion, serviceEngineGroup string) (setting *ControllerSettings) {
 	setting = DefaultControllerSettings()
 	setting.CloudName = cloudName
 	setting.ControllerIP = controllerIP
 	setting.ServiceEngineGroupName = serviceEngineGroup
+	if controllerVersion != "" {
+		setting.ControllerVersion = controllerVersion
+	}
 	return
 }
 

--- a/pkg/ako/values_test.go
+++ b/pkg/ako/values_test.go
@@ -37,25 +37,25 @@ var _ = Describe("AKO", func() {
 			rbac := config.Rbac
 
 			expectedPairs := map[string]string{
-				akoSettings.ClusterName:                                             "test",
-				akoSettings.LogLevel:                                                akoDeploymentConfig.Spec.ExtraConfigs.Log.LogLevel,      // use default value if not provided
-				akoSettings.FullSyncFrequency:                                       akoDeploymentConfig.Spec.ExtraConfigs.FullSyncFrequency, // use default value if not provided
-				akoSettings.CniPlugin:                                               akoDeploymentConfig.Spec.ExtraConfigs.CniPlugin,
-				akoSettings.DisableStaticRouteSync:                                  strconv.FormatBool(*akoDeploymentConfig.Spec.ExtraConfigs.DisableStaticRouteSync),
-				controllerSettings.CloudName:                                        akoDeploymentConfig.Spec.CloudName,
-				controllerSettings.ControllerIP:                                     akoDeploymentConfig.Spec.Controller,
-				controllerSettings.ServiceEngineGroupName:                           akoDeploymentConfig.Spec.ServiceEngineGroup,
-				networkSettings.NetworkName:                                         akoDeploymentConfig.Spec.DataNetwork.Name,
-				networkSettings.SubnetIP:                                            "10.0.0.0",
-				networkSettings.SubnetPrefix:                                        "24",
-				config.PersistentVolumeClaim:                                        akoDeploymentConfig.Spec.ExtraConfigs.Log.PersistentVolumeClaim,
-				config.MountPath:                                                    akoDeploymentConfig.Spec.ExtraConfigs.Log.MountPath,
-				config.LogFile:                                                      akoDeploymentConfig.Spec.ExtraConfigs.Log.LogFile,
-				value.LoadBalancerAndIngressService.Name:                            "ako-test",
-				rbac.PspPolicyApiVersion:                                            akoDeploymentConfig.Spec.ExtraConfigs.Rbac.PspPolicyAPIVersion,
-				rbac.PspPolicyApiVersion:                                            "test/1.2",
-				l7Settings.ShardVSSize:                                              akoDeploymentConfig.Spec.ExtraConfigs.IngressConfigs.ShardVSSize,
-				l7Settings.ServiceType:                                              akoDeploymentConfig.Spec.ExtraConfigs.IngressConfigs.ServiceType,
+				akoSettings.ClusterName:                   "test",
+				akoSettings.LogLevel:                      akoDeploymentConfig.Spec.ExtraConfigs.Log.LogLevel,      // use default value if not provided
+				akoSettings.FullSyncFrequency:             akoDeploymentConfig.Spec.ExtraConfigs.FullSyncFrequency, // use default value if not provided
+				akoSettings.CniPlugin:                     akoDeploymentConfig.Spec.ExtraConfigs.CniPlugin,
+				akoSettings.DisableStaticRouteSync:        strconv.FormatBool(*akoDeploymentConfig.Spec.ExtraConfigs.DisableStaticRouteSync),
+				controllerSettings.CloudName:              akoDeploymentConfig.Spec.CloudName,
+				controllerSettings.ControllerIP:           akoDeploymentConfig.Spec.Controller,
+				controllerSettings.ServiceEngineGroupName: akoDeploymentConfig.Spec.ServiceEngineGroup,
+				networkSettings.NetworkName:               akoDeploymentConfig.Spec.DataNetwork.Name,
+				networkSettings.SubnetIP:                  "10.0.0.0",
+				networkSettings.SubnetPrefix:              "24",
+				config.PersistentVolumeClaim:              akoDeploymentConfig.Spec.ExtraConfigs.Log.PersistentVolumeClaim,
+				config.MountPath:                          akoDeploymentConfig.Spec.ExtraConfigs.Log.MountPath,
+				config.LogFile:                            akoDeploymentConfig.Spec.ExtraConfigs.Log.LogFile,
+				value.LoadBalancerAndIngressService.Name:  "ako-test",
+				rbac.PspPolicyApiVersion:                  akoDeploymentConfig.Spec.ExtraConfigs.Rbac.PspPolicyAPIVersion,
+				rbac.PspPolicyApiVersion:                  "test/1.2",
+				l7Settings.ShardVSSize:                    akoDeploymentConfig.Spec.ExtraConfigs.IngressConfigs.ShardVSSize,
+				l7Settings.ServiceType:                    akoDeploymentConfig.Spec.ExtraConfigs.IngressConfigs.ServiceType,
 			}
 			for k, v := range expectedPairs {
 				Expect(k).To(Equal(v))


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

Since `AKO Operator` and  `AKO` both support multi AVI Controller versions, this PR makes AVI Controller Version configurable, so users can set the controller version to be the one they actually deployed.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.

/kind enhancement
