### PR TITLE
Disable "label PRs from globs" and "on comment" since bot has no admin access.

### DIFF
--- a/.github/workflows/on-comments.yml
+++ b/.github/workflows/on-comments.yml
@@ -1,7 +1,9 @@
 name: "React to commands in comments"
 on:
-  issue_comment:
-    types: [created]
+
+#  will uncomment this after having the admin access
+#  issue_comment:
+#    types: [created]
 
 jobs:
   execute:

--- a/.github/workflows/pr-labelers.yml
+++ b/.github/workflows/pr-labelers.yml
@@ -1,6 +1,8 @@
 name: "Label PRs from globs"
 on:
-  - pull_request_target
+
+#  will uncomment this after having the admin access
+#  - pull_request_target
 
 jobs:
   triage:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,10 @@
 name: Mark stale issues and pull requests
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+
+#  will uncomment this after having the admin access
+#  schedule:
+#    - cron: "0 0 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables two github actions, "label PRs from globs" and "on comment" since bot has no admin access. It will make the checks pass for now.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # None

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.