### PR TITLE
Make the ADC spec.ClusterSelector immutable using webhook.

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_webhook_test.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook_test.go
@@ -4,10 +4,12 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestAdcControlPlaneNetworkImmutable(t *testing.T) {
@@ -123,6 +125,133 @@ func TestAdcControlPlaneNetworkImmutable(t *testing.T) {
 				g.Expect(newADC.ValidateUpdate(oldADC)).NotTo(Succeed())
 			} else {
 				g.Expect(newADC.ValidateUpdate(oldADC)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestAdcClusterSelectorNonEmpty(t *testing.T) {
+	CustomizedAkoDeploymentConfig := "install-ako-for-l7"
+	tests := []struct {
+		name             string
+		adcName          string
+		clusterSelector  metav1.LabelSelector
+		expectErr        bool
+		expectErrType    field.ErrorType
+		expectErrMessage string
+	}{
+		{
+			name:            "when default adc has empty cluster selector",
+			adcName:         WorkloadClusterAkoDeploymentConfig,
+			clusterSelector: metav1.LabelSelector{},
+			expectErr:       false,
+		},
+		{
+			name:            "when default adc has nonempty cluster selector",
+			adcName:         WorkloadClusterAkoDeploymentConfig,
+			clusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			expectErr:       false,
+		},
+		{
+			name:            "when customized adc has nonempty cluster selector",
+			adcName:         CustomizedAkoDeploymentConfig,
+			clusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			expectErr:       false,
+		},
+		{
+			name:             "when customized adc has empty cluster selector",
+			adcName:          CustomizedAkoDeploymentConfig,
+			clusterSelector:  metav1.LabelSelector{},
+			expectErr:        true,
+			expectErrType:    field.ErrorTypeInvalid,
+			expectErrMessage: "field should not be empty for non-default ADC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			adc := &AKODeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.adcName,
+				},
+				Spec: AKODeploymentConfigSpec{ClusterSelector: tt.clusterSelector},
+			}
+			err := adc.ValidateCreate()
+			if !tt.expectErr {
+				g.Expect(err).To(BeNil())
+			} else {
+				fieldErr, ok := err.(*errors.StatusError)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(fieldErr.Status().Details.Causes).To(Not(BeEmpty()))
+				g.Expect(fieldErr.Status().Details.Causes[0].String()).To(ContainSubstring(tt.expectErrType.String()))
+				g.Expect(fieldErr.Status().Details.Causes[0].String()).To(ContainSubstring(tt.expectErrMessage))
+			}
+		})
+	}
+}
+
+func TestAdcClusterSelectorImmutable(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldClusterSelector metav1.LabelSelector
+		newClusterSelector metav1.LabelSelector
+		expectErr          bool
+		expectErrType      field.ErrorType
+		expectErrMessage   string
+	}{
+		{
+			name:               "when label selector is not changed",
+			oldClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			newClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			expectErr:          false,
+		},
+		{
+			name:               "when label selector key is changed",
+			oldClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			newClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo1": "bar"}},
+			expectErr:          true,
+			expectErrType:      field.ErrorTypeInvalid,
+			expectErrMessage:   "field should not be changed",
+		},
+		{
+			name:               "when label selector value is changed",
+			oldClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			newClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar1"}},
+			expectErr:          true,
+			expectErrType:      field.ErrorTypeInvalid,
+			expectErrMessage:   "field should not be changed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			newADC := &AKODeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "integration-test-8ed12g",
+					Namespace: "integration-test-8ed12g",
+				},
+				Spec: AKODeploymentConfigSpec{ClusterSelector: tt.newClusterSelector},
+			}
+
+			oldADC := &AKODeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "integration-test-8ed12g",
+					Namespace: "integration-test-8ed12g",
+				},
+				Spec: AKODeploymentConfigSpec{ClusterSelector: tt.oldClusterSelector},
+			}
+
+			err := newADC.ValidateUpdate(oldADC)
+			if !tt.expectErr {
+				g.Expect(err).To(BeNil())
+			} else {
+				fieldErr, ok := err.(*errors.StatusError)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(fieldErr.Status().Details.Causes).To(Not(BeEmpty()))
+				g.Expect(fieldErr.Status().Details.Causes[0].String()).To(ContainSubstring(tt.expectErrType.String()))
+				g.Expect(fieldErr.Status().Details.Causes[0].String()).To(ContainSubstring(tt.expectErrMessage))
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the AKODeploymentConfig field `spec.ClusterSelector` to be immutable once created, in order to simplify cluster selection logics when reconciling.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
ADC webhook unit test


**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Make the ADC spec.ClusterSelector immutable using webhook.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-samples/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.