### PR TITLE
change default service type to NPL when CNI is antrea

### DIFF
--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -67,7 +67,7 @@ loadBalancerAndIngressService:
             auto_fqdn: ""
         controller_settings:
             service_engine_group_name: Default-SEG
-            controller_version: ""
+            controller_version: 20.1.3
             cloud_name: test-cloud
             controller_ip: 10.23.122.1
         nodeport_selector:


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- This PR changes the default service type to `NodePortLocal` when the CNI is antrea because NSX ALB NodePortLocal routing mode is cost-saving and less hop compared with `NodePort` or `ClusterIP` mode.

- This PR also removes useless default values of `shardVSSize`
   
   
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

- Unit test passed
- Integration test passed
- manually e2e test it.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.