### PR TITLE
Resume add usable network to cloud IPAM profile

### DIFF
--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -104,6 +104,7 @@ func (r *AKODeploymentConfigReconciler) reconcileAVI(
 
 	return phases.ReconcilePhases(ctx, log, obj, []phases.ReconcilePhase{
 		r.reconcileNetworkSubnets,
+		r.reconcileCloudUsableNetwork,
 		r.reconcileAviInfraSetting,
 		func(ctx context.Context, log logr.Logger, obj *akoov1alpha1.AKODeploymentConfig) (ctrl.Result, error) {
 			return phases.ReconcileClustersPhases(ctx, r.Client, log, obj,
@@ -203,26 +204,26 @@ func (r *AKODeploymentConfigReconciler) reconcileNetworkSubnets(
 	return res, nil
 }
 
-// func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
-// 	ctx context.Context,
-// 	log logr.Logger,
-// 	obj *akoov1alpha1.AKODeploymentConfig,
-// ) (ctrl.Result, error) {
-// 	log = log.WithValues("cloud", obj.Spec.CloudName)
-// 	log.Info("Start reconciling AVI cloud usable network")
+func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
+	ctx context.Context,
+	log logr.Logger,
+	obj *akoov1alpha1.AKODeploymentConfig,
+) (ctrl.Result, error) {
+	log = log.WithValues("cloud", obj.Spec.CloudName)
+	log.Info("Start reconciling AVI cloud usable network")
 
-// 	added, err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name)
-// 	if err != nil {
-// 		log.Error(err, "Failed to add usable network", "network", obj.Spec.DataNetwork.Name)
-// 		return ctrl.Result{}, err
-// 	}
-// 	if added {
-// 		log.Info("Added Usable Network", "network", obj.Spec.DataNetwork.Name)
-// 	} else {
-// 		log.Info("Network is already one of the cloud's usable network", "network", obj.Spec.DataNetwork.Name)
-// 	}
-// 	return ctrl.Result{}, nil
-// }
+	if err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.ControlPlaneNetwork.Name, log); err != nil {
+		log.Error(err, "Failed to add usable network", "network", obj.Spec.ControlPlaneNetwork.Name)
+		return ctrl.Result{}, err
+	}
+
+	if err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name, log); err != nil {
+		log.Error(err, "Failed to add usable network", "network", obj.Spec.DataNetwork.Name)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
 
 func (r *AKODeploymentConfigReconciler) reconcileAviInfraSetting(
 	ctx context.Context,

--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -120,15 +120,10 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	for _, vipNetwork := range vipNetworkList {
-		added, err := r.AddUsableNetwork(r.aviClient, cloudName, vipNetwork.NetworkName)
+		err := r.AddUsableNetwork(r.aviClient, cloudName, vipNetwork.NetworkName, log)
 		if err != nil {
 			log.Error(err, "Failed to add usable network", "network", vipNetwork.NetworkName)
 			return ctrl.Result{}, err
-		}
-		if added {
-			log.Info("Added Usable Network", "network", vipNetwork.NetworkName)
-		} else {
-			log.Info("Network is already one of the cloud's usable network", "network", vipNetwork.NetworkName)
 		}
 	}
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- This PR resumes the functionality that adding `AKODeploymentConfig` control plane or data plane network to cloud ipam profile's usable network.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.