### PR TITLE
Dynamically detect avi controller version and populate to akodeploymentconfig

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -35,7 +35,6 @@ const (
 	AkoConfigMapControllerIPKey   = "controllerIP"
 	AkoConfigMapVipNetworkListKey = "vipNetworkList"
 
-	AVI_VERSION                                                  = "20.1.3"
 	AviClusterLabel                                              = "networking.tkg.tanzu.vmware.com/avi"
 	AviClusterDeleteConfigLabel                                  = "networking.tkg.tanzu.vmware.com/avi-config-delete"
 	AviClusterSecretType                                         = "avi.cluster.x-k8s.io/secret"

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -72,7 +72,8 @@ func (r *AKODeploymentConfigReconciler) initAVI(
 		var err error
 		r.aviClient, err = aviclient.NewAviClientFromSecrets(r.Client, ctx, log, obj.Spec.Controller,
 			obj.Spec.AdminCredentialRef.Name, obj.Spec.AdminCredentialRef.Namespace,
-			obj.Spec.CertificateAuthorityRef.Name, obj.Spec.CertificateAuthorityRef.Namespace)
+			obj.Spec.CertificateAuthorityRef.Name, obj.Spec.CertificateAuthorityRef.Namespace,
+			obj.Spec.ControllerVersion)
 
 		if err != nil {
 			log.Error(err, "Cannot init AVI clients from secrets")

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -116,6 +116,7 @@ func unitTestAKODeploymentYaml() {
 					Spec: akoov1alpha1.AKODeploymentConfigSpec{
 						CloudName:          "test-cloud",
 						Controller:         "10.23.122.1",
+						ControllerVersion:  "20.1.3",
 						ServiceEngineGroup: "Default-SEG",
 						DataNetwork: akoov1alpha1.DataNetwork{
 							Name: "test-akdc",

--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -51,7 +51,7 @@ func (r *ConfigMapReconciler) initAVI(ctx context.Context,
 		var err error
 		r.aviClient, err = aviclient.NewAviClientFromSecrets(r.Client, ctx, log, controllerIP,
 			v1alpha1.AviCredentialName, v1alpha1.TKGSystemNamespace,
-			v1alpha1.AviCAName, v1alpha1.TKGSystemNamespace)
+			v1alpha1.AviCAName, v1alpha1.TKGSystemNamespace, "")
 		if err != nil {
 			log.Error(err, "Cannot init AVI clients from secrets")
 			return res, err

--- a/e2e/pkg/env/avi.go
+++ b/e2e/pkg/env/avi.go
@@ -9,8 +9,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/aviclient"
-
-	ako_operator "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako-operator"
 )
 
 func NewAviRunner(runner *KubectlRunner) aviclient.Client {
@@ -20,7 +18,7 @@ func NewAviRunner(runner *KubectlRunner) aviclient.Client {
 		Username: GetAviObject(runner, "secret", "controller-credentials", "data", "username"),
 		Password: GetAviObject(runner, "secret", "controller-credentials", "data", "password"),
 		CA:       GetAviObject(runner, "secret", "controller-ca", "data", "certificateAuthorityData"),
-	}, ako_operator.GetAVIControllerVersion())
+	}, "")
 
 	return aviClient
 }

--- a/pkg/ako-operator/config_envvar.go
+++ b/pkg/ako-operator/config_envvar.go
@@ -4,8 +4,6 @@
 package ako_operator
 
 import (
-	akoov1alpha1 "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/api/v1alpha1"
-
 	"os"
 	"strconv"
 )
@@ -23,9 +21,6 @@ const (
 
 	// ControlPlaneEndpointPort - defines the control plane endpoint port
 	ControlPlaneEndpointPort = "control_plane_endpoint_port"
-
-	// AVIControllerVersion - defines the AVI controller version load balancer operator will talk to
-	AVIControllerVersion = "avi_controller_version"
 )
 
 func IsBootStrapCluster() bool {
@@ -42,12 +37,4 @@ func GetControlPlaneEndpointPort() int32 {
 		return 6443
 	}
 	return int32(port)
-}
-
-func GetAVIControllerVersion() string {
-	version, set := os.LookupEnv(AVIControllerVersion)
-	if set && version != "" {
-		return version
-	}
-	return akoov1alpha1.AVI_VERSION
 }

--- a/pkg/ako-operator/config_envvar_test.go
+++ b/pkg/ako-operator/config_envvar_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	akoov1alpha1 "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/api/v1alpha1"
 )
 
 var _ = Describe("AKO Operator", func() {
@@ -50,32 +49,6 @@ var _ = Describe("AKO Operator", func() {
 			})
 			It("should return port 6443", func() {
 				Expect(GetControlPlaneEndpointPort()).Should(Equal(int32(6443)))
-			})
-		})
-	})
-
-	Context("Get AVI Controller Version", func() {
-		When("avi controller version is successfully set", func() {
-			BeforeEach(func() {
-				os.Setenv(AVIControllerVersion, "20.1.1")
-			})
-			It("should return version 20.1.1", func() {
-				Expect(GetAVIControllerVersion()).Should(Equal("20.1.1"))
-			})
-		})
-
-		When("avi controller version is set but the value is empty", func() {
-			BeforeEach(func() {
-				os.Setenv(AVIControllerVersion, "")
-			})
-			It("should return default avi controller version", func() {
-				Expect(GetAVIControllerVersion()).Should(Equal(akoov1alpha1.AVI_VERSION))
-			})
-		})
-
-		When("avi controller version is not set", func() {
-			It("should return default avi controller version", func() {
-				Expect(GetAVIControllerVersion()).Should(Equal(akoov1alpha1.AVI_VERSION))
 			})
 		})
 	})

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -398,7 +398,7 @@ type ControllerSettings struct {
 func DefaultControllerSettings() *ControllerSettings {
 	return &ControllerSettings{
 		// set controller version to the default one
-		ControllerVersion: akoov1alpha1.AVI_VERSION,
+		// ControllerVersion: populate in runtime,
 		// ServiceEngineGroupName: populate in runtime
 		// CloudName: populate in runtime
 		// ControllerIP: populate in runtime
@@ -414,9 +414,7 @@ func NewControllerSettings(cloudName, controllerIP, controllerVersion, serviceEn
 	setting.ControllerIP = controllerIP
 	setting.ServiceEngineGroupName = serviceEngineGroup
 	setting.TenantName = tenantName
-	if controllerVersion != "" {
-		setting.ControllerVersion = controllerVersion
-	}
+	setting.ControllerVersion = controllerVersion
 	return
 }
 

--- a/pkg/aviclient/fake_avi_client.go
+++ b/pkg/aviclient/fake_avi_client.go
@@ -128,6 +128,10 @@ func (r *FakeAviClient) AviCertificateConfig() (string, error) {
 	return "", nil
 }
 
+func (r *FakeAviClient) GetControllerVersion() (string, error) {
+	return "", nil
+}
+
 // ServiceEngineGroup Client
 type ServiceEngineGroupClient struct {
 	getByNameFn GetByNameSEGFunc

--- a/pkg/aviclient/interface.go
+++ b/pkg/aviclient/interface.go
@@ -36,4 +36,6 @@ type Client interface {
 	PoolGetByName(name string, options ...session.ApiOptionsParams) (*models.Pool, error)
 
 	AviCertificateConfig() (string, error)
+
+	GetControllerVersion() (string, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Dynamic detect the version of avi controller `AKODeploymentconfig` point to.
- Automatic  populate the right version to `AKODeploymentconfig.spec.controllerVersion`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
User doesn't need to specify controller version in akodeploymentconfig anymore
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.