### PR TITLE
follow up fix on avi controller version issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.14
+TKG_VERSION ?= v1.6.0+vmware.15
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

In the previous fix: https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/107, we do automatically detect the avi controller version and update avi client in the operator.
However, because the client is lazy-init and designed to be a singleton, so when the user has many `AKODeploymentConfig` objects, only one of them's `spec.ControllerVersion` gets updated (the one which first actual init avi client), other `AKODeploymentConfig` objects' `sepc.ControllerVersion` still don't get updated, this PR fixes this issue.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
user doesn't need to specify controller version in adc anymore
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.