### PR TITLE
Fix control plane network empty add usable network error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.15
+TKG_VERSION ?= v1.6.0+vmware.16
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -256,9 +256,11 @@ func (r *AKODeploymentConfigReconciler) reconcileCloudUsableNetwork(
 	log = log.WithValues("cloud", obj.Spec.CloudName)
 	log.Info("Start reconciling AVI cloud usable network")
 
-	if err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.ControlPlaneNetwork.Name, log); err != nil {
-		log.Error(err, "Failed to add usable network", "network", obj.Spec.ControlPlaneNetwork.Name)
-		return ctrl.Result{}, err
+	if obj.Spec.ControlPlaneNetwork.Name != "" && obj.Spec.ControlPlaneNetwork.CIDR != "" {
+		if err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.ControlPlaneNetwork.Name, log); err != nil {
+			log.Error(err, "Failed to add usable network", "network", obj.Spec.ControlPlaneNetwork.Name)
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.AddUsableNetwork(r.aviClient, obj.Spec.CloudName, obj.Spec.DataNetwork.Name, log); err != nil {


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- When users continue updating from 1.4.x -> 1.5.x -> 1.6.0, their `AKODeploymentConfig.spec.controlPlaneNetwork` will be empty, we should check this condition and do not try to add empty network to IPAM usable networks.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

- Unit test passed
- Locally test on vSphere env

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
none
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.