### PR TITLE
[cherry-pick] fix avi controller version validation & service engine group validation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.16.0 AS builder
+FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.17.0 AS builder
 # FROM golang:1.15.0 AS builder
 
 WORKDIR /workspace
@@ -11,7 +11,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-ENV GOPROXY=https://build-artifactory.eng.vmware.com/gocenter.io
+ENV GOPROXY=https://goproxy.io,direct
 RUN go mod download
 
 # Copy the go source

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.6.0+vmware.16
+TKG_VERSION ?= v1.6.0+vmware.17
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -90,7 +90,7 @@ func (r *AKODeploymentConfigReconciler) initAVI(
 			r.aviClient, err = aviclient.NewAviClientFromSecrets(r.Client, ctx, log, obj.Spec.Controller,
 				obj.Spec.AdminCredentialRef.Name, obj.Spec.AdminCredentialRef.Namespace,
 				obj.Spec.CertificateAuthorityRef.Name, obj.Spec.CertificateAuthorityRef.Namespace,
-				obj.Spec.ControllerVersion)
+				version)
 
 			if err != nil {
 				log.Error(err, "Cannot init AVI clients with actual avi controller version")
@@ -210,7 +210,7 @@ func (r *AKODeploymentConfigReconciler) reconcileNetworkSubnets(
 		return res, errors.New("AVI client not initialized")
 	}
 
-	network, err := r.aviClient.NetworkGetByName(obj.Spec.DataNetwork.Name)
+	network, err := r.aviClient.NetworkGetByName(obj.Spec.DataNetwork.Name, obj.Spec.CloudName)
 	if err != nil {
 		log.Info("[WARN] Failed to get the Data Network from AVI Controller")
 		return res, nil

--- a/pkg/aviclient/fake_avi_client.go
+++ b/pkg/aviclient/fake_avi_client.go
@@ -35,7 +35,7 @@ func NewFakeAviClient() *FakeAviClient {
 	}
 }
 
-func (r *FakeAviClient) ServiceEngineGroupGetByName(name string, options ...session.ApiOptionsParams) (*models.ServiceEngineGroup, error) {
+func (r *FakeAviClient) ServiceEngineGroupGetByName(name, cloudName string, options ...session.ApiOptionsParams) (*models.ServiceEngineGroup, error) {
 	return r.ServiceEngineGroup.GetByName(name)
 }
 
@@ -49,7 +49,7 @@ func (r *FakeAviClient) ServiceEngineGroupCreate(obj *models.ServiceEngineGroup,
 	return obj, nil
 }
 
-func (r *FakeAviClient) NetworkGetByName(name string, options ...session.ApiOptionsParams) (*models.Network, error) {
+func (r *FakeAviClient) NetworkGetByName(name, cloudName string, options ...session.ApiOptionsParams) (*models.Network, error) {
 	return r.Network.GetByName(name)
 }
 

--- a/pkg/aviclient/interface.go
+++ b/pkg/aviclient/interface.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Client interface {
-	ServiceEngineGroupGetByName(name string, options ...session.ApiOptionsParams) (*models.ServiceEngineGroup, error)
+	ServiceEngineGroupGetByName(name, cloudName string, options ...session.ApiOptionsParams) (*models.ServiceEngineGroup, error)
 	ServiceEngineGroupCreate(obj *models.ServiceEngineGroup, options ...session.ApiOptionsParams) (*models.ServiceEngineGroup, error)
 
-	NetworkGetByName(name string, options ...session.ApiOptionsParams) (*models.Network, error)
+	NetworkGetByName(name, cloudName string, options ...session.ApiOptionsParams) (*models.Network, error)
 	NetworkCreate(obj *models.Network, options ...session.ApiOptionsParams) (*models.Network, error)
 	NetworkUpdate(obj *models.Network, options ...session.ApiOptionsParams) (*models.Network, error)
 

--- a/pkg/netprovider/network_provider.go
+++ b/pkg/netprovider/network_provider.go
@@ -20,10 +20,6 @@ type UsableNetwork struct {
 type UsableNetworkProvider struct{}
 
 func (c *UsableNetworkProvider) AddUsableNetwork(client aviclient.Client, cloudName, networkName string, log logr.Logger) error {
-	network, err := client.NetworkGetByName(networkName)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get Data Network %s from AVI Controller\n", networkName)
-	}
 	cloud, err := client.CloudGetByName(cloudName)
 	if err != nil {
 		// Cannot find the configured cloud, requeue the request but
@@ -40,7 +36,10 @@ func (c *UsableNetworkProvider) AddUsableNetwork(client aviclient.Client, cloudN
 	if err != nil {
 		return errors.Wrap(err, "Failed to find IPAM profile")
 	}
-
+	network, err := client.NetworkGetByName(networkName, cloudName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get Data Network %s from AVI Controller\n", networkName)
+	}
 	// Ensure network is added to the cloud's IPAM Profile as one of its
 	// usable Networks
 	for _, usableNetwork := range ipam.InternalProfile.UsableNetworks {


### PR DESCRIPTION

cherry-pick of https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/111

Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.