### PR TITLE
Fix AKODeploymentConfig control plane network can't be empty error

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_webhook.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook.go
@@ -295,6 +295,9 @@ func (r *AKODeploymentConfig) validateAviServiceEngineGroup() *field.Error {
 // validateAviControlPlaneNetworks checks input Control Plane Network name existing or not, CIDR format valid or not
 func (r *AKODeploymentConfig) validateAviControlPlaneNetworks() field.ErrorList {
 	var allErrs field.ErrorList
+	if r.Spec.ControlPlaneNetwork.Name == "" || r.Spec.ControlPlaneNetwork.CIDR == "" {
+		return allErrs
+	}
 	// check control plane network name
 	if _, err := aviClient.NetworkGetByName(r.Spec.ControlPlaneNetwork.Name, r.Spec.CloudName); err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneNetwork", "name"),

--- a/api/v1alpha1/akodeploymentconfig_webhook_test.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook_test.go
@@ -183,6 +183,17 @@ func TestCreateNewAKODeploymentConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:              "control plane network field can be empty",
+			adminSecret:       staticAdminSecret.DeepCopy(),
+			certificateSecret: staticCASecret.DeepCopy(),
+			adc:               staticADC.DeepCopy(),
+			customizeInput: func(adminSecret, certificateSecret *corev1.Secret, adc *AKODeploymentConfig) (*corev1.Secret, *corev1.Secret, *AKODeploymentConfig) {
+				adc.Spec.ControlPlaneNetwork = ControlPlaneNetwork{}
+				return adminSecret, certificateSecret, adc
+			},
+			expectErr: false,
+		},
+		{
 			name:              "should throw error if not find avi admin secret or certificate sercret",
 			adminSecret:       staticAdminSecret.DeepCopy(),
 			certificateSecret: staticCASecret.DeepCopy(),


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- Fix the AKODeploymentConfig control plane network can't be empty issue.
- Control plane network is only required when users using NSX ALB to provide cluster endpoint and control plane HA. This one should be optional and when users left it blank, the webhook validation shouldn't fail.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

- TODO

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
users can leave spec.ControlPlaneNetwork field empty
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.