### PR TITLE
Align adc configurations with ako 1.8.1

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -27,7 +27,7 @@ type AKODeploymentConfigSpec struct {
 	Controller string `json:"controller"`
 
 	// ControllerVersion is the AVI Controller version which AKO Operator and AKO talks to.
-	// If not set, default version is 20.1.3
+	// this value can be auto detected and corrected.
 	ControllerVersion string `json:"controllerVersion,omitempty"`
 
 	// ServiceEngineGroup is the group name of Service Engine that's to be used by the set
@@ -162,6 +162,21 @@ type ExtraConfigs struct {
 	// default value is false
 	// +optional
 	VIPPerNamespace *bool `json:"vipPerNamespace,omitempty"`
+
+	// This flag needs to be enabled when AKO is be to brought up in an Istio environment
+	// default value is false
+	// +optional
+	IstioEnabled *bool `json:"istioEnabled,omitempty"`
+
+	// This is the list of system namespaces from which AKO will not listen any Kubernetes object event.
+	// +optional
+	BlockedNamespaceList []string `json:"blockedNamespaceList,omitempty"`
+
+	// This flag can take values V4 or V6 (default V4)
+	// default value is V4
+	// +kubebuilder:validation:Enum=V4;V6
+	// +optional
+	IpFamily string `json:"ipFamily,omitempty"`
 
 	// NetworksConfig specifies the network configurations for virtual services.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -316,6 +316,16 @@ func (in *ExtraConfigs) DeepCopyInto(out *ExtraConfigs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IstioEnabled != nil {
+		in, out := &in.IstioEnabled, &out.IstioEnabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.BlockedNamespaceList != nil {
+		in, out := &in.BlockedNamespaceList, &out.BlockedNamespaceList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.NetworksConfig.DeepCopyInto(&out.NetworksConfig)
 	in.IngressConfigs.DeepCopyInto(&out.IngressConfigs)
 	out.L4Configs = in.L4Configs

--- a/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
+++ b/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
@@ -149,7 +149,8 @@ spec:
                 type: string
               controllerVersion:
                 description: ControllerVersion is the AVI Controller version which
-                  AKO Operator and AKO talks to. If not set, default version is 20.1.3
+                  AKO Operator and AKO talks to. this value can be auto detected and
+                  corrected.
                 type: string
               dataNetwork:
                 description: DataNetworks describes the Data Networks the AKO will
@@ -194,6 +195,12 @@ spec:
                       server for the liveness probe of the AKO pod default port is
                       8080
                     type: integer
+                  blockedNamespaceList:
+                    description: This is the list of system namespaces from which
+                      AKO will not listen any Kubernetes object event.
+                    items:
+                      type: string
+                    type: array
                   cniPlugin:
                     description: 'CniPlugin describes which cni plugin cluster is
                       using. default value is antrea, set this string if cluster cni
@@ -295,6 +302,17 @@ spec:
                         - DEDICATED
                         type: string
                     type: object
+                  ipFamily:
+                    description: This flag can take values V4 or V6 (default V4) default
+                      value is V4
+                    enum:
+                    - V4
+                    - V6
+                    type: string
+                  istioEnabled:
+                    description: This flag needs to be enabled when AKO is be to brought
+                      up in an Istio environment default value is false
+                    type: boolean
                   l4Config:
                     description: IngressConfigs specifies L4 load balancer configuration
                       for ako

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -43,6 +43,9 @@ loadBalancerAndIngressService:
                 label_key: ""
                 label_value: ""
             enable_events: ""
+            istio_enabled: ""
+            blocked_namespace_list: ""
+            ip_family: ""
         network_settings:
             subnet_ip: 10.0.0.0
             subnet_prefix: "24"


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- Update AKODeploymentConfig to align configurations with AKO 1.8.1
- Support IPV6

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.