### PR TITLE
Fix the addon secret name

### DIFF
--- a/controllers/akodeploymentconfig/cluster/cluster_controller.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller.go
@@ -116,7 +116,7 @@ func (r *ClusterReconciler) cleanup(
 
 	secretName := r.akoAddonDataValueName()
 	if akoo.IsClusterClassBasedCluster(obj) {
-		secretName = r.akoAddonSecretName(obj)
+		secretName = r.akoAddonSecretNameForClusterClass(obj)
 	}
 	if err := remoteClient.Get(ctx, client.ObjectKey{
 		Name:      secretName,

--- a/controllers/akodeploymentconfig/cluster/cluster_controller.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller.go
@@ -114,6 +114,10 @@ func (r *ClusterReconciler) cleanup(
 
 	}
 
+	// in legacy cluster
+	//   - secret is load-balancer-and-ingress-service-data-values
+	// in clusterclass cluster
+	//   - secret is <cluster-name>-load-balancer-and-ingress-service-data-values
 	secretName := r.akoAddonDataValueName()
 	if akoo.IsClusterClassBasedCluster(obj) {
 		secretName = r.akoAddonSecretNameForClusterClass(obj)

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -134,6 +134,10 @@ func (r *ClusterReconciler) aviUserSecretName(cluster *clusterv1.Cluster) string
 }
 
 func (r *ClusterReconciler) akoAddonSecretName(cluster *clusterv1.Cluster) string {
+	return cluster.Name + "-load-balancer-and-ingress-service-addons"
+}
+
+func (r *ClusterReconciler) akoAddonSecretNameForClusterClass(cluster *clusterv1.Cluster) string {
 	return cluster.Name + "-load-balancer-and-ingress-service-data-values"
 }
 

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -134,7 +134,7 @@ func (r *ClusterReconciler) aviUserSecretName(cluster *clusterv1.Cluster) string
 }
 
 func (r *ClusterReconciler) akoAddonSecretName(cluster *clusterv1.Cluster) string {
-	return cluster.Name + "-load-balancer-and-ingress-service-addons"
+	return cluster.Name + "-load-balancer-and-ingress-service-addon"
 }
 
 func (r *ClusterReconciler) akoAddonSecretNameForClusterClass(cluster *clusterv1.Cluster) string {

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -94,7 +94,7 @@ WORKLOAD_CLUSTERS=${WORKLOAD_CLUSTERS:-"workload-cls"}
 function check_dependencies() {
   # Ensure Kind 0.7.0+ is available.
   command -v kind >/dev/null 2>&1 || fatal "kind 0.7.0+ is required"
-  if [[ 10#"$(kind --version 2>&1 | awk '{print $3}' | tr -d '.')" -lt 10#070 ]]; then
+  if [[ 10#"$(kind --version 2>&1 | awk '{print $3}' | tr -d '.')" < 10#070 ]]; then
     echo "kind 0.7.0+ is required" && exit 1
   fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In remote workload cluster
- in legacy cluster
       -  secret is `load-balancer-and-ingress-service-data-values`
- in clusterclass cluster
       - secret is `<clustername>-load-balancer-and-ingress-service-data-values `

Fix this PR's change https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/123/files

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.