### PR TITLE
Fix the ako addon secret type

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -18,6 +18,7 @@ const (
 	TKGAddOnLabelClusterNameKey    = "tkg.tanzu.vmware.com/cluster-name"
 	TKGAddOnLabelClusterctlKey     = "clusterctl.cluster.x-k8s.io/move"
 	TKGAddOnSecretType             = "tkg.tanzu.vmware.com/addon"
+	TKGClusterClassAddOnSecretType = "clusterbootstrap-secret"
 	TKGAddOnSecretDataKey          = "values.yaml"
 	TKGDataValueFormatString       = "#@data/values\n#@overlay/match-child-defaults missing_ok=True\n---\n"
 	TKGSkipDeletePkgiAnnotationKey = "run.tanzu.vmware.com/skip-packageinstall-deletion"

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -159,10 +159,14 @@ func (r *ClusterReconciler) createAKOAddonSecret(cluster *clusterv1.Cluster, obj
 				akoov1alpha1.TKGAddOnLabelClusterctlKey:  "",
 			},
 		},
-		Type: "Opaque",
+		Type: akoov1alpha1.TKGAddOnSecretType,
 		StringData: map[string]string{
 			akoov1alpha1.TKGAddOnSecretDataKey: secretStringData,
 		},
+	}
+
+	if akoo.IsClusterClassBasedCluster(cluster) {
+		secret.Type = akoov1alpha1.TKGClusterClassAddOnSecretType
 	}
 	return secret, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Secret type for 
non-classy tkg.tanzu.vmware.com/addon
classy clusterbootstrap-secret
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.