### PR TITLE
fix NSX ALB as cluster endpoint VIP provider control plane service got deleted problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.7.0+vmware.1
+TKG_VERSION ?= v1.7.0+vmware.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -80,8 +80,8 @@ func (r *ClusterReconciler) ReconcileAddonSecret(
 		return res, err
 	}
 
-	if akoo.IsClusterClassBasedCluster(cluster) {
-		// patch cluster bootstrap here
+	// patch cluster bootstrap when it is classy cluster and not in bootstrap cluster
+	if akoo.IsClusterClassBasedCluster(cluster) && !akoo.IsBootStrapCluster() {
 		if err := r.patchAkoPackageRefToClusterBootstrap(ctx, log, cluster); err != nil {
 			log.Error(err, "Failed to patch ako package ref to cluster bootstrap, requeue")
 			return res, err

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -82,6 +82,7 @@ func (r *ClusterReconciler) ReconcileAddonSecret(
 
 	// patch cluster bootstrap when it is classy cluster and not in bootstrap cluster
 	if akoo.IsClusterClassBasedCluster(cluster) && !akoo.IsBootStrapCluster() {
+		log.Info("patching clusterbootstrap with ako packageRef")
 		if err := r.patchAkoPackageRefToClusterBootstrap(ctx, log, cluster); err != nil {
 			log.Error(err, "Failed to patch ako package ref to cluster bootstrap, requeue")
 			return res, err

--- a/controllers/akodeploymentconfig/phases/phases.go
+++ b/controllers/akodeploymentconfig/phases/phases.go
@@ -89,10 +89,11 @@ func ReconcileClustersPhases(
 		// skip reconcile if cluster is using kube-vip to provide load balancer service
 		if isLBProvider, err := ako_operator.IsLoadBalancerProvider(&cluster); err != nil {
 			log.Error(err, "can't unmarshal cluster variables")
-			return res, err
+			allErrs = append(allErrs, err)
+			continue
 		} else if !isLBProvider {
 			log.Info(fmt.Sprintf("cluster uses kube-vip to provide load balancer type of service, skip reconciling for cluster %s/%s", cluster.Namespace, cluster.Name))
-			return res, nil
+			continue
 		}
 
 		// Always Patch for each cluster when exiting this function so changes to the resource are updated on the API server.

--- a/controllers/akodeploymentconfig/phases/phases.go
+++ b/controllers/akodeploymentconfig/phases/phases.go
@@ -5,6 +5,7 @@ package phases
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -90,7 +91,7 @@ func ReconcileClustersPhases(
 			log.Error(err, "can't unmarshal cluster variables")
 			return res, err
 		} else if !isLBProvider {
-			log.Info("cluster uses kube-vip to provide load balancer type of service, skip reconciling")
+			log.Info(fmt.Sprintf("cluster uses kube-vip to provide load balancer type of service, skip reconciling for cluster %s/%s", cluster.Namespace, cluster.Name))
 			return res, nil
 		}
 

--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -89,7 +89,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 			log.Error(err, "Fail to reconcile HA service")
 			return res, err
 		}
-		if ako_operator.IsBootStrapCluster() {
+		if ako_operator.IsLegacyBootStrapCluster() {
 			return res, nil
 		}
 	}

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -20,7 +20,7 @@ func SetupReconcilers(mgr ctrl.Manager) error {
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}
-	if !akoo.IsBootStrapCluster() {
+	if !akoo.IsLegacyBootStrapCluster() {
 		// if the ako-operator manager is deployed on management cluster
 		// it will reconcile against any AKODeploymentConfig
 		if err := (&akodeploymentconfig.AKODeploymentConfigReconciler{

--- a/controllers/machine/machine_controller.go
+++ b/controllers/machine/machine_controller.go
@@ -105,7 +105,7 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 			log.Error(err, "Fail to reconcile HA endpoint")
 			return res, err
 		}
-		if ako_operator.IsBootStrapCluster() {
+		if ako_operator.IsLegacyBootStrapCluster() {
 			return res, nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	//setup webhook here
-	if !ako_operator.IsBootStrapCluster() {
+	if !ako_operator.IsLegacyBootStrapCluster() {
 		err = (&akoov1alpha1.AKODeploymentConfig{}).SetupWebhookWithManager(mgr)
 		if err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "AKODeploymentConfig")

--- a/pkg/ako-operator/lib.go
+++ b/pkg/ako-operator/lib.go
@@ -31,6 +31,9 @@ const (
 
 // ClusterClass Env variables
 const (
+	// ClusterClassEnabled - helps check if cluster is classy based cluster when no cluster object create yet.
+	ClusterClassEnabled = "cluster_class_enabled"
+
 	// KubeVipLoadBalancerProvider - defines if cluster using kube-vip to implement load balancer
 	// type of service
 	KubeVipLoadBalancerProvider = "kubeVipLoadBalancerProvider"
@@ -45,8 +48,16 @@ const (
 	ApiServerPort = "apiServerPort"
 )
 
+func IsLegacyBootStrapCluster() bool {
+	return IsBootStrapCluster() && !IsClusterClassEnabled()
+}
+
 func IsBootStrapCluster() bool {
 	return os.Getenv(DeployInBootstrapCluster) == "True"
+}
+
+func IsClusterClassEnabled() bool {
+	return os.Getenv(ClusterClassEnabled) == "True"
 }
 
 // IsClusterClassBasedCluster checks if a cluster is cluster class based cluster

--- a/pkg/ako-operator/lib_test.go
+++ b/pkg/ako-operator/lib_test.go
@@ -94,6 +94,37 @@ var _ = Describe("AKO Operator lib unit test", func() {
 		})
 	})
 
+	Context("If ako operator is deployed in bootstrap cluster", func() {
+		When("set cluster_class_enabled to true ", func() {
+			BeforeEach(func() {
+				os.Setenv(ClusterClassEnabled, "True")
+			})
+			AfterEach(func() {
+				os.Unsetenv(ClusterClassEnabled)
+			})
+			It("should return True", func() {
+				Expect(IsClusterClassEnabled()).Should(Equal(true))
+			})
+		})
+		When("set cluster_class_enabled to false ", func() {
+			BeforeEach(func() {
+				os.Setenv(ClusterClassEnabled, "False")
+			})
+			AfterEach(func() {
+				os.Unsetenv(ClusterClassEnabled)
+			})
+			It("should return false", func() {
+				Expect(IsClusterClassEnabled()).Should(Equal(false))
+			})
+		})
+		When("didn't set cluster_class_enabled", func() {
+			It("should return false", func() {
+				Expect(IsClusterClassEnabled()).Should(Equal(false))
+			})
+		})
+
+	})
+
 	Context("ako operator control plane HA provider", func() {
 		Context("Legacy Cluster Cases", func() {
 			When("ako operator provides control plane HA", func() {

--- a/pkg/handlers/cluster_for_akodeploymentconfig_handler.go
+++ b/pkg/handlers/cluster_for_akodeploymentconfig_handler.go
@@ -52,6 +52,7 @@ func AkoDeploymentConfigForCluster(c client.Client, log logr.Logger) handler.Map
 			ako_operator.ApplyClusterLabel(log, cluster, adcForCluster)
 			requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{Name: adcForCluster.Name}})
 		}
+		// TODO: change to patch instead of retry
 		// update cluster with avi label
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			return c.Update(ctx, cluster)

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -150,7 +150,7 @@ func (r *HAProvider) annotateService(ctx context.Context, cluster *clusterv1.Clu
 		akoov1alpha1.TKGClusterNameSpaceLabel: cluster.Namespace,
 	}
 
-	if ako_operator.IsBootStrapCluster() {
+	if ako_operator.IsLegacyBootStrapCluster() {
 		return serviceAnnotation, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- fix NSX ALB as cluster endpoint VIP provider control plane service got deleted problem

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.