### PR TITLE
Fix keep adding the same network to cloud's ipam profile usable network issue

### DIFF
--- a/pkg/netprovider/network_provider.go
+++ b/pkg/netprovider/network_provider.go
@@ -4,6 +4,8 @@
 package netprovider
 
 import (
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/aviclient"
@@ -42,8 +44,10 @@ func (c *UsableNetworkProvider) AddUsableNetwork(client aviclient.Client, cloudN
 	}
 	// Ensure network is added to the cloud's IPAM Profile as one of its
 	// usable Networks
+	// sample network url: https://1.1.1.1/api/network/network-38-cloud-c654fba6-6486-4595-911d-52a8f1fbbf77#testnetwork
+	// sample usable network ref: https://1.1.1.1/api/network/network-38-cloud-c654fba6-6486-4595-911d-52a8f1fbbf77
 	for _, usableNetwork := range ipam.InternalProfile.UsableNetworks {
-		if *usableNetwork.NwRef == *(network.URL) {
+		if strings.Contains(*(network.URL), *(usableNetwork.NwRef)) {
 			log.Info("Network is already one of the cloud's usable network", "network", networkName)
 			return nil
 		}


### PR DESCRIPTION

Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

- Fix load balancer operator keeps adding the same network to cloud's ipam profile usable network issue

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.