### PR TITLE
Change to use node name to filter the machine in the endpoints

### DIFF
--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -230,7 +230,7 @@ func (r *HAProvider) updateClusterControlPlaneEndpoint(cluster *clusterv1.Cluste
 	return errors.New(service.Name + " service external ip is not ready")
 }
 
-func (r *HAProvider) syncEndpointMachineIP(address *corev1.EndpointAddress, machine *clusterv1.Machine) {
+func (r *HAProvider) syncEndpointMachineIP(address corev1.EndpointAddress, machine *clusterv1.Machine) corev1.EndpointAddress {
 	// check if ip is still in the machine's address
 	found := false
 	for _, machineAddress := range machine.Status.Addresses {
@@ -242,25 +242,22 @@ func (r *HAProvider) syncEndpointMachineIP(address *corev1.EndpointAddress, mach
 		}
 	}
 
-	if found {
-		// no need to sync mahcine ip
-		return
-	}
-
-	// machine address is not sync with the ip address in endpoints object
-	// update endpoints object
-	for _, machineAddress := range machine.Status.Addresses {
-		if machineAddress.Type != clusterv1.MachineExternalIP {
-			continue
-		}
-		if net.ParseIP(machineAddress.Address) != nil {
-			address.IP = machineAddress.Address
-			r.log.Info("sync endpoints object, update machine: " + machine.Name + " ip to:" + address.IP)
-			return
-		} else {
-			r.log.Info(machineAddress.Address + " is not a valid IP address")
+	if !found {
+		// machine address is not sync with the ip address in endpoints object
+		// update endpoints object
+		for _, machineAddress := range machine.Status.Addresses {
+			if machineAddress.Type != clusterv1.MachineExternalIP {
+				continue
+			}
+			if net.ParseIP(machineAddress.Address) != nil && net.ParseIP(machineAddress.Address).To4() != nil {
+				address.IP = machineAddress.Address
+				r.log.Info("sync endpoints object, update machine: " + machine.Name + "'s ip to:" + address.IP)
+			} else {
+				r.log.Info(machineAddress.Address + " is not a valid IPv4 address")
+			}
 		}
 	}
+	return address
 }
 
 func (r *HAProvider) removeMachineIpFromEndpoints(endpoints *corev1.Endpoints, machine *clusterv1.Machine) {
@@ -270,9 +267,11 @@ func (r *HAProvider) removeMachineIpFromEndpoints(endpoints *corev1.Endpoints, m
 	}
 	newAddresses := make([]corev1.EndpointAddress, 0)
 	for _, address := range endpoints.Subsets[0].Addresses {
-		if address.NodeName != &machine.Name {
-			newAddresses = append(newAddresses, address)
+		// skip the machine should be deleted
+		if address.NodeName != nil && *address.NodeName == machine.Name {
+			continue
 		}
+		newAddresses = append(newAddresses, address)
 	}
 	endpoints.Subsets[0].Addresses = newAddresses
 	// remove the Subset if "Addresses" is emtpy
@@ -293,10 +292,10 @@ func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machin
 		}}
 	} else {
 		// check if machine has already been added to Endpoints
-		for _, address := range endpoints.Subsets[0].Addresses {
-			if address.NodeName == &machine.Name {
+		for i, address := range endpoints.Subsets[0].Addresses {
+			if address.NodeName != nil && *address.NodeName == machine.Name {
 				r.log.Info("machine is in Endpoints Object")
-				r.syncEndpointMachineIP(&address, machine)
+				endpoints.Subsets[0].Addresses[i] = r.syncEndpointMachineIP(address, machine)
 				return
 			}
 		}
@@ -307,7 +306,8 @@ func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machin
 			continue
 		}
 		// check machineAddress.Address is valid
-		if net.ParseIP(machineAddress.Address) != nil {
+		// only support IPv4 for now
+		if net.ParseIP(machineAddress.Address) != nil && net.ParseIP(machineAddress.Address).To4() != nil {
 			newAddress := corev1.EndpointAddress{
 				IP:       machineAddress.Address,
 				NodeName: &machine.Name,
@@ -315,7 +315,7 @@ func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machin
 			endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, newAddress)
 			break
 		} else {
-			r.log.Info(machineAddress.Address + " is not a valid IP address")
+			r.log.Info(machineAddress.Address + " is not a valid IPv4 address")
 		}
 	}
 }
@@ -344,7 +344,7 @@ func (r *HAProvider) CreateOrUpdateHAEndpoints(ctx context.Context, machine *clu
 	}
 
 	if !machine.DeletionTimestamp.IsZero() {
-		r.log.Info("machine is being deleted, remove the endpoint of the machine from " + r.getHAServiceName(cluster) + " Endpoints")
+		r.log.Info("machine" + machine.Name + " is being deleted, remove the endpoint of the machine from " + r.getHAServiceName(cluster) + " Endpoints")
 		r.removeMachineIpFromEndpoints(endpoints, machine)
 	} else {
 		// Add machine ip to the Endpoints object no matter it's ready or not

--- a/pkg/haprovider/haprovider_test.go
+++ b/pkg/haprovider/haprovider_test.go
@@ -1,0 +1,227 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package haprovider
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/pointer"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("Control Plane HA provider", func() {
+	var (
+		ctx        context.Context
+		haProvider HAProvider
+		err        error
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(clusterv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		log.SetLogger(zap.New())
+		fc := fakeClient.NewClientBuilder().WithScheme(scheme).Build()
+		logger := log.Log
+		haProvider = *NewProvider(fc, logger)
+	})
+
+	Context("Test_CreateOrUpdateHAEndpoints", func() {
+		var (
+			mc      *clusterv1.Machine
+			cluster *clusterv1.Cluster
+			ep      *corev1.Endpoints
+			key     client.ObjectKey
+		)
+		BeforeEach(func() {
+			mc = &clusterv1.Machine{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-mc",
+					Namespace: "default",
+				},
+				Spec: clusterv1.MachineSpec{},
+			}
+			cluster = &clusterv1.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterSpec{},
+			}
+		})
+
+		JustBeforeEach(func() {
+			err = haProvider.CreateOrUpdateHAEndpoints(ctx, mc)
+		})
+
+		It("machine is not a control plane machine, should skip", func() {
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		When("machine is a control plane machine", func() {
+			BeforeEach(func() {
+				mc.ObjectMeta.Labels = map[string]string{clusterv1.MachineControlPlaneLabelName: ""}
+				mc.Spec.ClusterName = "test-cluster"
+			})
+
+			It("the cluster machine belong doesn't exist, should throw out cluster not found error", func() {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			When("the cluster machine belongs to exist", func() {
+				BeforeEach(func() {
+					Expect(haProvider.Client.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+					mc.Status.Addresses = clusterv1.MachineAddresses{
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "1.1.1.1",
+						},
+					}
+					ep = &corev1.Endpoints{}
+					key = client.ObjectKey{Name: haProvider.getHAServiceName(cluster), Namespace: mc.Namespace}
+				})
+
+				AfterEach(func() {
+					Expect(haProvider.Client.Delete(ctx, ep)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Delete(ctx, cluster)).ShouldNot(HaveOccurred())
+				})
+
+				It("Should create a endpoints object and machine to the endpoints", func() {
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))
+					Expect(ep.Subsets[0].Addresses[0].NodeName).Should(Equal(pointer.StringPtr("test-mc")))
+				})
+
+				It("should not add a duplicated machine", func() {
+					mc2 := mc.DeepCopy()
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc2)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))
+					Expect(ep.Subsets[0].Addresses[0].NodeName).Should(Equal(pointer.StringPtr("test-mc")))
+				})
+
+				It("should not add machine's other type IP", func() {
+					mc2 := mc.DeepCopy()
+					mc2.Name = "test-mc-2"
+					mc2.Status.Addresses = clusterv1.MachineAddresses{
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineInternalIP,
+							Address: "1.1.1.1",
+						},
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "test123",
+						},
+					}
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc2)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))
+					Expect(ep.Subsets[0].Addresses[0].NodeName).Should(Equal(pointer.StringPtr("test-mc")))
+				})
+
+				It("should update endpoints when machine ip changed", func() {
+					mc.Status.Addresses = clusterv1.MachineAddresses{
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "1.1.1.2",
+						},
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineInternalIP,
+							Address: "1.1.1.3",
+						},
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "test123",
+						},
+					}
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.2"))
+					Expect(ep.Subsets[0].Addresses[0].NodeName).Should(Equal(pointer.StringPtr("test-mc")))
+				})
+
+				It("should remove machine from endpoints when machine deleting", func() {
+					time := v1.Now()
+					mc.DeletionTimestamp = &time
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(ep.Subsets).Should(BeNil())
+				})
+
+				It("[two machines] should delete the second machine", func() {
+					mc2 := mc.DeepCopy()
+					mc2.Name = "test-mc-2"
+					mc2.Status.Addresses = clusterv1.MachineAddresses{
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "1.1.1.2",
+						},
+					}
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc2)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(2))
+
+					time := v1.Now()
+					mc.DeletionTimestamp = &time
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.2"))
+					Expect(ep.Subsets[0].Addresses[0].NodeName).Should(Equal(pointer.StringPtr("test-mc-2")))
+
+					mc2.DeletionTimestamp = &time
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc2)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets)).Should(Equal(0))
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets)).Should(Equal(0))
+				})
+
+				// Once dual-stack is supported, change this test case
+				It("Should Only support IPV4 for now", func() {
+					mc2 := mc.DeepCopy()
+					mc2.Name = "test-mc-2"
+					mc2.Status.Addresses = clusterv1.MachineAddresses{
+						clusterv1.MachineAddress{
+							Type:    clusterv1.MachineExternalIP,
+							Address: "fd01:3:4:2877:250:56ff:feb4:adaf",
+						},
+					}
+
+					Expect(haProvider.CreateOrUpdateHAEndpoints(ctx, mc2)).ShouldNot(HaveOccurred())
+					Expect(haProvider.Client.Get(ctx, key, ep)).ShouldNot(HaveOccurred())
+					Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+				})
+			})
+
+		})
+
+	})
+})

--- a/pkg/haprovider/suite_test.go
+++ b/pkg/haprovider/suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package haprovider
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Control Plane HA provider suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Change to use node name to filter the machine in the endpoints

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.