### PR TITLE
align ako 1.9.2 & deprecate .spec.loadBalancerIP

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -178,6 +178,12 @@ type ExtraConfigs struct {
 	// +optional
 	IpFamily string `json:"ipFamily,omitempty"`
 
+	// If this flag is set to true, AKO will only handle default secrets from the namespace where AKO is installed
+	// This flag is applicable only to Openshift clusters
+	// default value is false
+	// +optional
+	UseDefaultSecretsOnly *bool `json:"useDefaultSecretsOnly,omitempty"`
+
 	// NetworksConfig specifies the network configurations for virtual services.
 	// +optional
 	NetworksConfig NetworksConfig `json:"networksConfig,omitempty"`

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -38,6 +38,7 @@ const (
 	AkoConfigMapVipNetworkListKey    = "vipNetworkList"
 	AkoClusterBootstrapRefNamePrefix = "load-balancer-and-ingress-service.tanzu.vmware.com"
 	AkoPackageInstallName            = "load-balancer-and-ingress-service"
+	AkoPreferredIPAnnotation         = "ako.vmware.com/load-balancer-ip"
 
 	AviClusterLabel                                              = "networking.tkg.tanzu.vmware.com/avi"
 	AviClusterDeleteConfigLabel                                  = "networking.tkg.tanzu.vmware.com/avi-config-delete"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -326,6 +326,11 @@ func (in *ExtraConfigs) DeepCopyInto(out *ExtraConfigs) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UseDefaultSecretsOnly != nil {
+		in, out := &in.UseDefaultSecretsOnly, &out.UseDefaultSecretsOnly
+		*out = new(bool)
+		**out = **in
+	}
 	in.NetworksConfig.DeepCopyInto(&out.NetworksConfig)
 	in.IngressConfigs.DeepCopyInto(&out.IngressConfigs)
 	out.L4Configs = in.L4Configs

--- a/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
+++ b/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
@@ -423,6 +423,12 @@ spec:
                       which are not backward compatible with the advancedL4 APIs which
                       uses a fork and a version of v1alpha1pre1 default value is false'
                     type: boolean
+                  useDefaultSecretsOnly:
+                    description: If this flag is set to true, AKO will only handle
+                      default secrets from the namespace where AKO is installed This
+                      flag is applicable only to Openshift clusters default value
+                      is false
+                    type: boolean
                   vipPerNamespace:
                     description: Enabling this flag would tell AKO to create Parent
                       VS per Namespace in EVH mode default value is false

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -425,6 +425,12 @@ spec:
                       which are not backward compatible with the advancedL4 APIs which
                       uses a fork and a version of v1alpha1pre1 default value is false'
                     type: boolean
+                  useDefaultSecretsOnly:
+                    description: If this flag is set to true, AKO will only handle
+                      default secrets from the namespace where AKO is installed This
+                      flag is applicable only to Openshift clusters default value
+                      is false
+                    type: boolean
                   vipPerNamespace:
                     description: Enabling this flag would tell AKO to create Parent
                       VS per Namespace in EVH mode default value is false

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_unit_test.go
@@ -46,6 +46,7 @@ loadBalancerAndIngressService:
             istio_enabled: ""
             blocked_namespace_list: ""
             ip_family: ""
+            use_default_secrets_only: ""
         network_settings:
             subnet_ip: 10.0.0.0
             subnet_prefix: "24"

--- a/controllers/cluster/cluster_intg_test.go
+++ b/controllers/cluster/cluster_intg_test.go
@@ -142,7 +142,7 @@ func intgTestEnsureClusterHAProvider() {
 
 					err := ctx.Client.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: ctx.Namespace}, service)
 					Expect(err).ShouldNot(HaveOccurred())
-					Expect(service.Spec.LoadBalancerIP).Should(Equal("10.1.2.1"))
+					Expect(service.Annotations[akoov1alpha1.AkoPreferredIPAnnotation]).Should(Equal("10.1.2.1"))
 				})
 			})
 		})

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -149,6 +149,7 @@ type AKOSettings struct {
 	BlockedNamespaceList     []string          `yaml:"-"`
 	BlockedNamespaceListJson string            `yaml:"blocked_namespace_list"`
 	IpFamily                 string            `yaml:"ip_family"`
+	UseDefaultSecretsOnly    string            `yaml:"use_default_secrets_only"`
 }
 
 type CNI string
@@ -222,6 +223,9 @@ func NewAKOSettings(clusterName string, obj *akoov1alpha1.AKODeploymentConfig) (
 	}
 	if obj.Spec.ExtraConfigs.IstioEnabled != nil {
 		settings.IstioEnabled = strconv.FormatBool(*obj.Spec.ExtraConfigs.IstioEnabled)
+	}
+	if obj.Spec.ExtraConfigs.UseDefaultSecretsOnly != nil {
+		settings.UseDefaultSecretsOnly = strconv.FormatBool(*obj.Spec.ExtraConfigs.UseDefaultSecretsOnly)
 	}
 	if obj.Spec.ExtraConfigs.IpFamily != "" {
 		settings.IpFamily = obj.Spec.ExtraConfigs.IpFamily

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -128,7 +128,7 @@ func (r *HAProvider) createService(
 		r.log.Error(err, "can't unmarshal cluster variables ", "endpoint", endpoint)
 		return nil, err
 	} else if endpoint != "" {
-		// "endpoint" can be ipv4 or hostname, add ipv4 or hostname to service.Spec.LoadBalancerIP
+		// "endpoint" can be ipv4 or hostname, add ipv4 or hostname as annotation: ako.vmware.com/load-balancer-ip:<ip>
 		if net.ParseIP(endpoint) == nil {
 			endpoint, err = QueryFQDN(endpoint)
 			if err != nil {
@@ -136,7 +136,10 @@ func (r *HAProvider) createService(
 				return nil, err
 			}
 		}
+		// update the load balancer ip spec & annotation as intermediate plan to
+		// tolerant older and newer version TKr
 		service.Spec.LoadBalancerIP = endpoint
+		service.Annotations[akoov1alpha1.AkoPreferredIPAnnotation] = endpoint
 	}
 	r.log.Info("Creating " + serviceName + " Service")
 	err = r.Create(ctx, service)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Algin new changes in AKO 1.9.2
- Deprecate `loadbalancer.spec.loadBalancerIP`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.