### PR TITLE
Fix management cluster endpoint vip provision race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.8.0+vmware.1
+TKG_VERSION ?= v1.9.0+vmware.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -163,6 +163,10 @@ func (r *HAProvider) annotateService(ctx context.Context, cluster *clusterv1.Clu
 	}
 	//no adc is selected for cluster, no annotation is needed.
 	if adcForCluster == nil {
+		// for the management cluster, it needs to requeue until the install-ako-for-management-cluster AKODeploymentConfig created
+		if _, ok := cluster.Labels[akoov1alpha1.TKGManagememtClusterRoleLabel]; ok {
+			return serviceAnnotation, errors.New("management cluster's AKODeploymentConfig didn't find, requeue to wait for AKODeploymentConfig created")
+		}
 		return serviceAnnotation, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- There might be a race condition during installing `ako-operator` application in the management cluster: if the ako operator pod is deployed, and `install-ako-for-management-cluster` AKODeploymentConfig doesn't get created yet, there is a chance that the management cluster control plane load balancer type of service loses aviinfrasetting annotation.
- This PR will throw an error to keep requeue reconciling if `install-ako-for-management-cluster` doesn't get created yet.
 
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.