### PR TITLE
Bump ako-operator to 1.10.0+vmware.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.9.0+vmware.1
+TKG_VERSION ?= v1.10.0+vmware.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -131,8 +131,10 @@ type ExtraConfigs struct {
 
 	// CniPlugin describes which cni plugin cluster is using.
 	// default value is antrea, set this string if cluster cni is other type.
-	// AKO supported CNI: antrea|calico|canal|flannel|openshift|ncp
-	// +kubebuilder:validation:Enum=antrea;calico;canal;flannel;openshift;ncp
+	// For Cilium CNI, set the string as cilium only when using Cluster Scope mode for IPAM
+	// and leave it empty if using Kubernetes Host Scope mode for IPAM.
+	// AKO supported CNI: antrea|calico|canal|flannel|openshift|ncp|ovn-kubernetes|cilium
+	// +kubebuilder:validation:Enum=antrea;calico;canal;flannel;openshift;ncp;ovn-kubernetes;cilium
 	// +optional
 	CniPlugin string `json:"cniPlugin,omitempty"`
 

--- a/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
+++ b/config/crd/bases/networking.tkg.tanzu.vmware.com_akodeploymentconfigs.yaml
@@ -204,7 +204,10 @@ spec:
                   cniPlugin:
                     description: 'CniPlugin describes which cni plugin cluster is
                       using. default value is antrea, set this string if cluster cni
-                      is other type. AKO supported CNI: antrea|calico|canal|flannel|openshift|ncp'
+                      is other type. For Cilium CNI, set the string as cilium only
+                      when using Cluster Scope mode for IPAM and leave it empty if
+                      using Kubernetes Host Scope mode for IPAM. AKO supported CNI:
+                      antrea|calico|canal|flannel|openshift|ncp|ovn-kubernetes|cilium'
                     enum:
                     - antrea
                     - calico
@@ -212,6 +215,8 @@ spec:
                     - flannel
                     - openshift
                     - ncp
+                    - ovn-kubernetes
+                    - cilium
                     type: string
                   disableStaticRouteSync:
                     description: DisableStaticRouteSync describes ako should sync

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -206,7 +206,10 @@ spec:
                   cniPlugin:
                     description: 'CniPlugin describes which cni plugin cluster is
                       using. default value is antrea, set this string if cluster cni
-                      is other type. AKO supported CNI: antrea|calico|canal|flannel|openshift|ncp'
+                      is other type. For Cilium CNI, set the string as cilium only
+                      when using Cluster Scope mode for IPAM and leave it empty if
+                      using Kubernetes Host Scope mode for IPAM. AKO supported CNI:
+                      antrea|calico|canal|flannel|openshift|ncp|ovn-kubernetes|cilium'
                     enum:
                     - antrea
                     - calico
@@ -214,6 +217,8 @@ spec:
                     - flannel
                     - openshift
                     - ncp
+                    - ovn-kubernetes
+                    - cilium
                     type: string
                   disableStaticRouteSync:
                     description: DisableStaticRouteSync describes ako should sync


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump AKO Operator 1.10.0 to align with AKO 1.10.x

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Bump ako-operator to 1.10.0
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.