### PR TITLE
fix cluster upgrade ako role doesn't update issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PUBLISH?=publish
 BUILD_VERSION ?= $(shell git describe --always --match "v*" | sed 's/v//')
 
 # TKG Version
-TKG_VERSION ?= v1.10.0+vmware.1
+TKG_VERSION ?= v1.10.0+vmware.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
@@ -260,7 +260,32 @@ func intgTestAkoDeploymentConfigController() {
 		})
 		ctx.AviClient.Role.SetCreateRoleFunc(func(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
 			userRoleCreateCalled = true
-			return &models.Role{}, nil
+			return &models.Role{
+				Privileges: []*models.Permission{
+					{
+						Type:     pointer.StringPtr("READ_ACCESS"),
+						Resource: pointer.StringPtr("PERMISSION_SYSTEMCONFIGURATION"),
+					},
+					{
+						Type:     pointer.StringPtr("READ_ACCESS"),
+						Resource: pointer.StringPtr("PERMISSION_CONTROLLER"),
+					},
+				},
+			}, nil
+		})
+		ctx.AviClient.Role.SetUpdateRoleFunc(func(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
+			return &models.Role{
+				Privileges: []*models.Permission{
+					{
+						Type:     pointer.StringPtr("READ_ACCESS"),
+						Resource: pointer.StringPtr("PERMISSION_SYSTEMCONFIGURATION"),
+					},
+					{
+						Type:     pointer.StringPtr("READ_ACCESS"),
+						Resource: pointer.StringPtr("PERMISSION_CONTROLLER"),
+					},
+				},
+			}, nil
 		})
 		ctx.AviClient.Tenant.SetGetTenantFunc(func(uuid string, options ...session.ApiOptionsParams) (*models.Tenant, error) {
 			return &models.Tenant{}, nil
@@ -525,6 +550,23 @@ func intgTestAkoDeploymentConfigController() {
 							})
 
 							When("AVI user exists", func() {
+								BeforeEach(func() {
+									ctx.AviClient.Role.SetGetByNameRoleFunc(func(name string, options ...session.ApiOptionsParams) (*models.Role, error) {
+										return &models.Role{
+											Privileges: []*models.Permission{
+												{
+													Type:     pointer.StringPtr("READ_ACCESS"),
+													Resource: pointer.StringPtr("PERMISSION_SYSTEMCONFIGURATION"),
+												},
+												{
+													Type:     pointer.StringPtr("READ_ACCESS"),
+													Resource: pointer.StringPtr("PERMISSION_CONTROLLER"),
+												},
+											},
+										}, nil
+									})
+								})
+
 								It("should update AVI user", func() {
 									Eventually(func() bool {
 										return userUpdateCalled

--- a/pkg/aviclient/client.go
+++ b/pkg/aviclient/client.go
@@ -276,6 +276,10 @@ func (r *realAviClient) RoleCreate(obj *models.Role, options ...session.ApiOptio
 	return r.Role.Create(obj)
 }
 
+func (r *realAviClient) RoleUpdate(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
+	return r.Role.Update(obj)
+}
+
 func (r *realAviClient) VirtualServiceGetByName(name string, options ...session.ApiOptionsParams) (*models.VirtualService, error) {
 	return r.VirtualService.GetByName(name)
 }

--- a/pkg/aviclient/fake_avi_client.go
+++ b/pkg/aviclient/fake_avi_client.go
@@ -116,6 +116,10 @@ func (r *FakeAviClient) RoleCreate(obj *models.Role, options ...session.ApiOptio
 	return r.Role.Create(obj)
 }
 
+func (r *FakeAviClient) RoleUpdate(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
+	return r.Role.Update(obj)
+}
+
 func (r *FakeAviClient) VirtualServiceGetByName(name string, options ...session.ApiOptionsParams) (*models.VirtualService, error) {
 	return r.VirtualService.GetByName(name)
 }
@@ -276,10 +280,12 @@ func (client *TenantClient) Get(uuid string, options ...session.ApiOptionsParams
 type RoleClient struct {
 	getByNameRoleFn GetByNameRoleFunc
 	createRoleFunc  CreateRoleFunc
+	updateRoleFunc  UpdateRoleFunc
 }
 
 type GetByNameRoleFunc func(name string, options ...session.ApiOptionsParams) (*models.Role, error)
 type CreateRoleFunc func(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error)
+type UpdateRoleFunc func(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error)
 
 func (client *RoleClient) SetGetByNameRoleFunc(fn GetByNameRoleFunc) {
 	client.getByNameRoleFn = fn
@@ -289,12 +295,20 @@ func (client *RoleClient) SetCreateRoleFunc(fn CreateRoleFunc) {
 	client.createRoleFunc = fn
 }
 
+func (client *RoleClient) SetUpdateRoleFunc(fn UpdateRoleFunc) {
+	client.updateRoleFunc = fn
+}
+
 func (client *RoleClient) GetByName(name string, options ...session.ApiOptionsParams) (*models.Role, error) {
 	return client.getByNameRoleFn(name)
 }
 
 func (client *RoleClient) Create(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
 	return client.createRoleFunc(obj)
+}
+
+func (client *RoleClient) Update(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error) {
+	return client.updateRoleFunc(obj)
 }
 
 // Pool Client

--- a/pkg/aviclient/interface.go
+++ b/pkg/aviclient/interface.go
@@ -27,6 +27,7 @@ type Client interface {
 
 	RoleGetByName(name string, options ...session.ApiOptionsParams) (*models.Role, error)
 	RoleCreate(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error)
+	RoleUpdate(obj *models.Role, options ...session.ApiOptionsParams) (*models.Role, error)
 
 	IPAMDNSProviderProfileGet(uuid string, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error)
 	IPAMDNSProviderProfileUpdate(obj *models.IPAMDNSProviderProfile, options ...session.ApiOptionsParams) (*models.IPAMDNSProviderProfile, error)


### PR DESCRIPTION
**What this PR does / why we need it**:


- fix when cluster upgrade, ako-oprator doesn't update ako-essential-role to align with latest permission


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.