### PR TITLE
Add v6cidr config for AVIInfraSettng and VIPNetworkList

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_types.go
+++ b/api/v1alpha1/akodeploymentconfig_types.go
@@ -367,7 +367,8 @@ type ControlPlaneNetwork struct {
 // VIPNetwork describes a VIPNetwork in the adc file
 type VIPNetwork struct {
 	NetworkName string `json:"networkName"`
-	CIDR        string `json:"cidr"`
+	CIDR        string `json:"cidr,omitempty"`
+	V6CIDR      string `json:"v6cidr,omitempty"`
 }
 
 // IPPool defines a contiguous range of IP Addresses

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9
-	github.com/vmware/alb-sdk v0.0.0-20221125101019-1edb021a121b
-	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20211102041403-f2ed902e4706
+	github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea
+	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20230828061312-c0f989362139
 	go.uber.org/zap v1.19.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -754,11 +754,10 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vmware-tanzu/service-apis v0.0.0-20200901171416-461d35e58618/go.mod h1:afqpDk9He9v+/qWix0RRotm3RNyni4Lmc1y9geDCPuo=
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9 h1:6syWK17nxSy26pyziCVSzd2ugTSqU3b2Rbx5Sx6djNY=
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9/go.mod h1:QiVC4POQPEu3/eNLZOHFrjyRGwWp6AVpZRADBIK1uEc=
-github.com/vmware/alb-sdk v0.0.0-20210721142023-8e96475b833b/go.mod h1:GuFjFl3UCYMUyEnbwPjpu+9wlkGs/10xuJuqE/1rqKI=
-github.com/vmware/alb-sdk v0.0.0-20221125101019-1edb021a121b h1:i04Do2br1qqs/ReZLXescGpST0QXIZVUSzhdLROkIPg=
-github.com/vmware/alb-sdk v0.0.0-20221125101019-1edb021a121b/go.mod h1:fuRb4saDY/xy/UMeMvyKYmcplNknEL9ysaqYSw7reNE=
-github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20211102041403-f2ed902e4706 h1:NnULYqZpRAgF/4NsMK/iprw5t6Z3EU7UoJl3j9EPbBs=
-github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20211102041403-f2ed902e4706/go.mod h1:AcBGOFqEpoLa1aU+r5Sq+j7MWlGKUsqAziKK3iKm678=
+github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea h1:ZcleA18Of+bECNwSMGPmGehqCuaJhq5SXxY6ETP0m6g=
+github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea/go.mod h1:fuRb4saDY/xy/UMeMvyKYmcplNknEL9ysaqYSw7reNE=
+github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20230828061312-c0f989362139 h1:jwIM/pxMSxkWGoehQB+4DJfZ3sTg41nlCyWmM34q5Yk=
+github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20230828061312-c0f989362139/go.mod h1:FerB1xAjr3OiCbJdgceJ6jSO8d5rjcXgDphWH091cqk=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/ako/values.go
+++ b/pkg/ako/values.go
@@ -6,6 +6,7 @@ package ako
 import (
 	"encoding/json"
 	"errors"
+	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/utils"
 	"math/rand"
 	"net"
 	"strconv"
@@ -282,7 +283,12 @@ func NewNetworkSettings(obj *akoov1alpha1.AKODeploymentConfig) (*NetworkSettings
 	settings.SubnetPrefix = strconv.Itoa(ones)
 
 	settings.NodeNetworkList = obj.Spec.ExtraConfigs.IngressConfigs.NodeNetworkList
-	settings.VIPNetworkList = []v1alpha1.VIPNetwork{{NetworkName: obj.Spec.DataNetwork.Name, CIDR: obj.Spec.DataNetwork.CIDR}}
+	//V6CIDR will enable the VS networks to use ipv6
+	if utils.GetIPFamilyFromCidr(obj.Spec.DataNetwork.CIDR) == "V6" {
+		settings.VIPNetworkList = []v1alpha1.VIPNetwork{{NetworkName: obj.Spec.DataNetwork.Name, V6CIDR: obj.Spec.DataNetwork.CIDR}}
+	} else {
+		settings.VIPNetworkList = []v1alpha1.VIPNetwork{{NetworkName: obj.Spec.DataNetwork.Name, CIDR: obj.Spec.DataNetwork.CIDR}}
+	}
 
 	if len(settings.NodeNetworkList) != 0 {
 		jsonBytes, err := json.Marshal(settings.NodeNetworkList)

--- a/pkg/utils/get_ipfamily.go
+++ b/pkg/utils/get_ipfamily.go
@@ -1,0 +1,28 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"net"
+)
+
+const (
+	InvalidIPFamily = "INVALID"
+	IPv4IpFamily    = "V4"
+	IPv6IpFamily    = "V6"
+)
+
+func GetIPFamilyFromCidr(cidr string) string {
+	addr, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return InvalidIPFamily
+	}
+
+	addrType := IPv4IpFamily
+	if addr.To4() == nil {
+		addrType = IPv6IpFamily
+	}
+
+	return addrType
+}

--- a/pkg/utils/get_ipfamily_test.go
+++ b/pkg/utils/get_ipfamily_test.go
@@ -1,0 +1,31 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+
+
+var _ = ginkgo.Describe("Test get primary ipFamily", func() {
+	ginkgo.It("should return V4 from CIDR", func() {
+		cidr := "192.168.0.0/16"
+		ipFamily := GetIPFamilyFromCidr(cidr)
+		Expect(ipFamily).To(Equal("V4"))
+	})
+
+	ginkgo.It("should return V6 from CIDR", func() {
+		cidr := "2002::1234:abcd:ffff:c0a8:101/64"
+		ipFamily := GetIPFamilyFromCidr(cidr)
+		Expect(ipFamily).To(Equal("V6"))
+	})
+
+	ginkgo.It("should return INVALID from CIDR", func() {
+		cidr := "2002::1234:abcd:ffff:c0a8:101"
+		ipFamily := GetIPFamilyFromCidr(cidr)
+		Expect(ipFamily).To(Equal("INVALID"))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Add v6cidr config for AVIInfraSettng and VIPNetworkList for dual stack support

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
unit tests and manually test on testbed

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.