### PR TITLE
use small go runner

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,7 @@ on:
       - Makefile
       - ".github/workflows/*.yml"
       - "codecov.yml"
+      - Dockerfile
 
 jobs:
   lint:
@@ -50,7 +51,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: '1.20' # The Go version to download (if necessary) and use.
       - name: Build hack tools for unit testing
         run: cd hack/tools && make controller-gen etcd ginkgo kustomize
 
@@ -74,7 +75,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: '1.20' # The Go version to download (if necessary) and use.
       - name: Build hack tools for integration testing
         run: cd hack/tools && make controller-gen etcd ginkgo kustomize
       - name: Perform integration tests
@@ -88,7 +89,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: '1.20' # The Go version to download (if necessary) and use.
 
       # uncomment this step for debugging: tmate session
 #      - name: Setup tmate session

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.20.3 AS builder
-# FROM golang:1.15.0 AS builder
+FROM golang:1.20.3-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
**What this PR does / why we need it**:

- use smaller go runner to fast the pre-merge pipeline and expose lass CVEs

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.