### PR TITLE
Add Avi Control Plane HA IPv6 support

### DIFF
--- a/api/v1alpha1/akodeploymentconfig_webhook.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook.go
@@ -327,17 +327,18 @@ func (r *AKODeploymentConfig) validateAviDataNetworks() field.ErrorList {
 	}
 	// check network cidr
 	addr, cidr, err := net.ParseCIDR(r.Spec.DataNetwork.CIDR)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "dataNetwork", "cidr"),
+			r.Spec.DataNetwork.CIDR,
+			"data plane network cidr "+r.Spec.DataNetwork.CIDR+" is not valid:"+err.Error()))
+	}
 	addrType := "INVALID"
 	if addr.To4() != nil {
 		addrType = "V4"
 	} else if addr.To16() != nil {
 		addrType = "V6"
 	}
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "dataNetwork", "cidr"),
-			r.Spec.DataNetwork.CIDR,
-			"data plane network cidr "+r.Spec.DataNetwork.CIDR+" is not valid:"+err.Error()))
-	}
+
 	// check data network ip pools
 	for _, ipPool := range r.Spec.DataNetwork.IPPools {
 		ipStart := net.ParseIP(ipPool.Start)

--- a/api/v1alpha1/akodeploymentconfig_webhook_test.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook_test.go
@@ -338,6 +338,27 @@ func TestCreateNewAKODeploymentConfig(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:              "valid ipv6 cidr",
+			adminSecret:       staticAdminSecret.DeepCopy(),
+			certificateSecret: staticCASecret.DeepCopy(),
+			adc:               staticADC.DeepCopy(),
+			customizeInput: func(adminSecret, certificateSecret *corev1.Secret, adc *AKODeploymentConfig) (*corev1.Secret, *corev1.Secret, *AKODeploymentConfig) {
+				adc.Spec.DataNetwork = DataNetwork{
+					Name: "VM Network 1",
+					CIDR: "2002::1234:abcd:ffff:c0a8:101/64",
+					IPPools: []IPPool{
+						{
+							Start: "2002::1234:abcd:ffff:c0a8:101",
+							End:   "2002::1234:abcd:ffff:c0a8:102",
+							Type:  "V6",
+						},
+					},
+				}
+				return adminSecret, certificateSecret, adc
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/api/v1alpha1/akodeploymentconfig_webhook_test.go
+++ b/api/v1alpha1/akodeploymentconfig_webhook_test.go
@@ -317,6 +317,27 @@ func TestCreateNewAKODeploymentConfig(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:              "should throw error if addr type doesn't match ippool type",
+			adminSecret:       staticAdminSecret.DeepCopy(),
+			certificateSecret: staticCASecret.DeepCopy(),
+			adc:               staticADC.DeepCopy(),
+			customizeInput: func(adminSecret, certificateSecret *corev1.Secret, adc *AKODeploymentConfig) (*corev1.Secret, *corev1.Secret, *AKODeploymentConfig) {
+				adc.Spec.DataNetwork = DataNetwork{
+					Name: "VM Network 1",
+					CIDR: "10.0.0.1/24",
+					IPPools: []IPPool{
+						{
+							Start: "2002::1234:abcd:ffff:c0a8:101/64",
+							End:   "2002::1234:abcd:ffff:c0a8:102/64",
+							Type:  "V6",
+						},
+					},
+				}
+				return adminSecret, certificateSecret, adc
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -60,7 +60,7 @@ func (r *ClusterReconciler) ReconcileAddonSecret(
 	}
 
 	//Stop reconciling if AKO ip family doesn't match cluster ip family
-	if err = validateADCAndClusterIpFamily(cluster, obj, isVIPProvider, log); err != nil {
+	if err = ValidateADCAndClusterIpFamily(cluster, obj, isVIPProvider, log); err != nil {
 		errInfo := "Selected AKODeploymentConfig " + obj.Name + "'s IP family doesn't match cluster " + cluster.Namespace +
 			"-" + cluster.Name + "'s ip family, stop deploying AKO into cluster " + cluster.Namespace + "-" + cluster.Name
 		log.Error(err, errInfo)
@@ -358,7 +358,7 @@ func getAKOPackageRefFromClusterBootstrap(log logr.Logger, cb *runv1alpha3.Clust
 	return -1, nil
 }
 
-func validateADCAndClusterIpFamily(cluster *clusterv1.Cluster, adc *akoov1alpha1.AKODeploymentConfig, isVIPProvider bool, log logr.Logger) error {
+func ValidateADCAndClusterIpFamily(cluster *clusterv1.Cluster, adc *akoov1alpha1.AKODeploymentConfig, isVIPProvider bool, log logr.Logger) error {
 	adcIpFamily := "V4"
 	if adc.Spec.ExtraConfigs.IpFamily != "" {
 		adcIpFamily = adc.Spec.ExtraConfigs.IpFamily

--- a/controllers/akodeploymentconfig/cluster/suite_test.go
+++ b/controllers/akodeploymentconfig/cluster/suite_test.go
@@ -36,4 +36,5 @@ func intgTests() {
 
 func unitTests() {
 	Describe("AKO Deployment Spec generation", unitTestAKODeploymentYaml)
+	Describe("AKODeploymentConfig and cluster ip family Validation", unitTestValidateADCAndClusterIpFamily)
 }

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -5,6 +5,7 @@ package haprovider
 
 import (
 	"context"
+	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/utils"
 	"net"
 	"sync"
 
@@ -134,7 +135,8 @@ func (r *HAProvider) createService(
 		r.log.Error(err, "can't unmarshal cluster variables ", "endpoint", endpoint)
 		return nil, err
 	} else if endpoint != "" {
-		// "endpoint" can be ipv4 or hostname, add ipv4 or hostname as annotation: ako.vmware.com/load-balancer-ip:<ip>
+		// "endpoint" can be ipv4/ipv6 or hostname, add ipv4/ipv6 or hostname as annotation: ako.vmware.com/load-balancer-ip:<ip>
+		// Limitation: Incheon doesn't support ipv6 endpoint because of AKO limitation
 		if net.ParseIP(endpoint) == nil {
 			endpoint, err = QueryFQDN(endpoint)
 			if err != nil {
@@ -270,11 +272,11 @@ func (r *HAProvider) syncEndpointMachineIP(address corev1.EndpointAddress, machi
 			if machineAddress.Type != clusterv1.MachineExternalIP {
 				continue
 			}
-			if net.ParseIP(machineAddress.Address) != nil && net.ParseIP(machineAddress.Address).To4() != nil {
+			if net.ParseIP(machineAddress.Address) != nil {
 				address.IP = machineAddress.Address
 				r.log.Info("sync endpoints object, update machine: " + machine.Name + "'s ip to:" + address.IP)
 			} else {
-				r.log.Info(machineAddress.Address + " is not a valid IPv4 address")
+				r.log.Info(machineAddress.Address + " is not a valid IP address")
 			}
 		}
 	}
@@ -301,7 +303,7 @@ func (r *HAProvider) removeMachineIpFromEndpoints(endpoints *corev1.Endpoints, m
 	}
 }
 
-func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machine *clusterv1.Machine) {
+func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machine *clusterv1.Machine, ipFamily string) {
 	if endpoints.Subsets == nil {
 		// create a Subset if Endpoint doesn't have one
 		endpoints.Subsets = []corev1.EndpointSubset{{
@@ -327,16 +329,26 @@ func (r *HAProvider) addMachineIpToEndpoints(endpoints *corev1.Endpoints, machin
 			continue
 		}
 		// check machineAddress.Address is valid
-		// only support IPv4 for now
-		if net.ParseIP(machineAddress.Address) != nil && net.ParseIP(machineAddress.Address).To4() != nil {
+		// Support IPv4 and IPv6
+		if net.ParseIP(machineAddress.Address) != nil {
 			newAddress := corev1.EndpointAddress{
 				IP:       machineAddress.Address,
 				NodeName: &machine.Name,
 			}
-			endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, newAddress)
-			break
+			//Validate MachineIP before adding to Endpoint
+			if ipFamily == "V6" {
+				if net.ParseIP(machineAddress.Address).To4() == nil {
+					endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, newAddress)
+					break
+				}
+			} else if ipFamily == "V4" {
+				if net.ParseIP(machineAddress.Address).To4() != nil {
+					endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, newAddress)
+					break
+				}
+			}
 		} else {
-			r.log.Info(machineAddress.Address + " is not a valid IPv4 address")
+			r.log.Info(machineAddress.Address + " is not a valid IP address")
 		}
 	}
 }
@@ -364,13 +376,24 @@ func (r *HAProvider) CreateOrUpdateHAEndpoints(ctx context.Context, machine *clu
 		return err
 	}
 
+	// Get control plane endpoint ip family
+	adcForCluster, err := r.getADCForCluster(ctx, cluster)
+	if err != nil {
+		r.log.Error(err, "Failed to get cluster AKODeploymentConfig")
+		return err
+	}
+	ipFamily := "V4"
+	if adcForCluster != nil {
+		ipFamily = utils.GetIPFamilyFromCidr(adcForCluster.Spec.DataNetwork.CIDR)
+
+	}
 	if !machine.DeletionTimestamp.IsZero() {
 		r.log.Info("machine" + machine.Name + " is being deleted, remove the endpoint of the machine from " + r.getHAServiceName(cluster) + " Endpoints")
 		r.removeMachineIpFromEndpoints(endpoints, machine)
 	} else {
 		// Add machine ip to the Endpoints object no matter it's ready or not
 		// Because avi controller checks the status of machine. If it's not ready, avi won't use it as an endpoint
-		r.addMachineIpToEndpoints(endpoints, machine)
+		r.addMachineIpToEndpoints(endpoints, machine, ipFamily)
 	}
 	if err := r.Update(ctx, endpoints); err != nil {
 		return errors.Wrapf(err, "Failed to update endpoints <%s>, control plane machine IP doesn't get allocated yet\n", endpoints.Name)

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -5,7 +5,6 @@ package haprovider
 
 import (
 	"context"
-	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/utils"
 	"net"
 	"sync"
 
@@ -136,7 +135,7 @@ func (r *HAProvider) createService(
 		return nil, err
 	} else if endpoint != "" {
 		// "endpoint" can be ipv4/ipv6 or hostname, add ipv4/ipv6 or hostname as annotation: ako.vmware.com/load-balancer-ip:<ip>
-		// Limitation: Incheon doesn't support ipv6 endpoint because of AKO limitation
+		// doesn't support ipv6 endpoint because of AKO limitation: https://avinetworks.com/docs/ako/1.10/support-for-ipv6-in-ako/
 		if net.ParseIP(endpoint) == nil {
 			endpoint, err = QueryFQDN(endpoint)
 			if err != nil {
@@ -383,8 +382,8 @@ func (r *HAProvider) CreateOrUpdateHAEndpoints(ctx context.Context, machine *clu
 		return err
 	}
 	ipFamily := "V4"
-	if adcForCluster != nil {
-		ipFamily = utils.GetIPFamilyFromCidr(adcForCluster.Spec.DataNetwork.CIDR)
+	if adcForCluster != nil && adcForCluster.Spec.ExtraConfigs.IpFamily != "" {
+		ipFamily = adcForCluster.Spec.ExtraConfigs.IpFamily
 
 	}
 	if !machine.DeletionTimestamp.IsZero() {

--- a/pkg/utils/get_ipfamily.go
+++ b/pkg/utils/get_ipfamily.go
@@ -146,8 +146,6 @@ func GetPrimaryIPFamily(c *capi.Cluster) (string, error) {
 	}
 	if ipFamily == IPv4IpFamily || ipFamily == DualStackIPv4Primary{
 		return IPv4IpFamily, nil
-	} else if ipFamily == IPv6IpFamily || ipFamily == DualStackIPv6Primary{
-		return IPv6IpFamily, nil
 	}
-	return InvalidIPFamily, fmt.Errorf("Invalid IP Family")
+	return IPv6IpFamily, nil
 }

--- a/pkg/utils/get_ipfamily.go
+++ b/pkg/utils/get_ipfamily.go
@@ -134,3 +134,20 @@ func GetClusterIPFamily(c *capi.Cluster) (string, error) {
 	}
 	return podsIPFamily, nil
 }
+
+// GetPrimaryIPFamily returns a cluster primary IPFamily from the configuration provided.
+// 1. V4: single-stack ipv4/dual-stack ipv4 primary cluster
+// 2. V6: single-stack ipv6/dual-stack ipv6 primary cluster
+// 3. INVALID: invalid cluster
+func GetPrimaryIPFamily(c *capi.Cluster) (string, error) {
+	ipFamily, err := GetClusterIPFamily(c)
+	if err != nil {
+		return InvalidIPFamily, fmt.Errorf("Invalid IP Family: %s", err)
+	}
+	if ipFamily == IPv4IpFamily || ipFamily == DualStackIPv4Primary{
+		return IPv4IpFamily, nil
+	} else if ipFamily == IPv6IpFamily || ipFamily == DualStackIPv6Primary{
+		return IPv6IpFamily, nil
+	}
+	return InvalidIPFamily, fmt.Errorf("Invalid IP Family")
+}

--- a/pkg/utils/get_ipfamily_test.go
+++ b/pkg/utils/get_ipfamily_test.go
@@ -325,4 +325,183 @@ var _ = ginkgo.Describe("Test get primary ipFamily", func() {
 		Expect(ipFamily).To(Equal("V4,V6"))
 		Expect(err).To(BeNil())
 	})
+
+	ginkgo.It("should return ipv4", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V4"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return ipv6", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64"},
+					},
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V6"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return right ipfamily when service cidr is empty", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V6"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return right ipfamily when pod cidr is empty", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V4"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return right ipfamily when service cidr is empty", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V4"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return V4 when both podcidr and service cidr are empty", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V4"))
+		Expect(err).To(BeNil())
+	})
+
+	ginkgo.It("should return INVALID, if length of podcidr is larger than 2", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16","2002::1234:abcd:ffff:c0a8:101/64","10.10.0.0/16"},
+					},
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("INVALID"))
+		Expect(err).NotTo(BeNil())
+	})
+
+	ginkgo.It("should return INVALID, if pod family is different from service family", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64"},
+					},
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("INVALID"))
+		Expect(err).NotTo(BeNil())
+	})
+
+	ginkgo.It("should return primary ipfamily", func() {
+		clusterClassCluster := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-class-cluster",
+				Namespace: "default",
+			},
+			Spec: capi.ClusterSpec{
+				ClusterNetwork: &capi.ClusterNetwork{
+					Pods: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64", "192.168.0.0/16"},
+					},
+					Services: &capi.NetworkRanges{
+						CIDRBlocks: []string{"2002::1234:abcd:ffff:c0a8:101/64", "192.168.0.0/16"},
+					},
+				},
+			},
+		}
+		ipFamily, err := GetPrimaryIPFamily(clusterClassCluster)
+		Expect(ipFamily).To(Equal("V6"))
+		Expect(err).To(BeNil())
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Avi Control Plane HA IPv6 support

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
manually test in testbed
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.