### PR TITLE
Configure IPFamily in control plane HA service

### DIFF
--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -108,6 +108,7 @@ func (r *HAProvider) createService(
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
+			IPFamilies: []string{"IPv6"},
 			Ports: []corev1.ServicePort{{
 				Protocol:   "TCP",
 				Port:       port,

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -5,6 +5,7 @@ package haprovider
 
 import (
 	"context"
+	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/utils"
 	"net"
 	"sync"
 
@@ -23,6 +24,12 @@ import (
 	akoov1alpha1 "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/api/v1alpha1"
 	ako_operator "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako-operator"
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+)
+
+const (
+	IPv4IpFamily = "IPv4"
+	IPv6IpFamily = "IPv6"
+	IPv6IpType   = "V6"
 )
 
 type HAProvider struct {
@@ -96,6 +103,17 @@ func (r *HAProvider) createService(
 		return nil, err
 	}
 
+	// Get cluster primary ip family, which is used for HA service
+	primaryIPFamily, err := utils.GetPrimaryIPFamily(cluster)
+	if err != nil {
+		return nil, err
+	}
+	if primaryIPFamily == IPv6IpType {
+		primaryIPFamily = IPv6IpFamily
+	} else {
+		primaryIPFamily = IPv4IpFamily
+	}
+
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -108,7 +126,8 @@ func (r *HAProvider) createService(
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
-			IPFamilies: []string{"IPv6"},
+			//TODO:(chenlin) Add two ip families after AKO fully supports dual-stack load balancer type of service
+			IPFamilies: []corev1.IPFamily{corev1.IPFamily(primaryIPFamily)},
 			Ports: []corev1.ServicePort{{
 				Protocol:   "TCP",
 				Port:       port,

--- a/pkg/utils/get_ipfamily.go
+++ b/pkg/utils/get_ipfamily.go
@@ -144,7 +144,7 @@ func GetPrimaryIPFamily(c *capi.Cluster) (string, error) {
 	if err != nil {
 		return InvalidIPFamily, fmt.Errorf("Invalid IP Family: %s", err)
 	}
-	if ipFamily == IPv4IpFamily || ipFamily == DualStackIPv4Primary{
+	if ipFamily == IPv4IpFamily || ipFamily == DualStackIPv4Primary {
 		return IPv4IpFamily, nil
 	}
 	return IPv6IpFamily, nil

--- a/pkg/utils/get_ipfamily_test.go
+++ b/pkg/utils/get_ipfamily_test.go
@@ -448,7 +448,7 @@ var _ = ginkgo.Describe("Test get primary ipFamily", func() {
 			Spec: capi.ClusterSpec{
 				ClusterNetwork: &capi.ClusterNetwork{
 					Pods: &capi.NetworkRanges{
-						CIDRBlocks: []string{"192.168.0.0/16","2002::1234:abcd:ffff:c0a8:101/64","10.10.0.0/16"},
+						CIDRBlocks: []string{"192.168.0.0/16", "2002::1234:abcd:ffff:c0a8:101/64", "10.10.0.0/16"},
 					},
 					Services: &capi.NetworkRanges{
 						CIDRBlocks: []string{"192.168.0.0/16"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Configure IPFamily in control plane HA service

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually test in testbed, ipFamilies can be configured correctly in ha service
```
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: fd00:100:64::ba30
  clusterIPs:
  - fd00:100:64::ba30
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv6
  ipFamilyPolicy: SingleStack
  loadBalancerIP: 10.161.136.142
  ports:
```
**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.