### PR TITLE
Set nsx-t t1 router value in aviinfrasetting

### DIFF
--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_avi_phase.go
@@ -328,6 +328,11 @@ func (r *AKODeploymentConfigReconciler) createAviInfraSetting(adc *akoov1alpha1.
 		}}
 	}
 
+	t1LR := pointer.StringPtr("")
+	if adc.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR != "" {
+		t1LR = pointer.StringPtr(adc.Spec.ExtraConfigs.NetworksConfig.NsxtT1LR)
+	}
+
 	return &akov1beta1.AviInfraSetting{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: haprovider.GetAviInfraSettingName(adc),
@@ -344,7 +349,7 @@ func (r *AKODeploymentConfigReconciler) createAviInfraSetting(adc *akoov1alpha1.
 			},
 			// Known issue: T1LR value is required when reconciling AKODeploymentConfig
 			NSXSettings: akov1beta1.AviInfraNSXSettings{
-				T1LR: pointer.StringPtr(""),
+				T1LR: t1LR,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Set nsx-t t1 router value in aviinfrasetting

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
manual test:
adc:
```
extraConfigs:
    cniPlugin: antrea
    disableStaticRouteSync: false
    featureGates:
      GatewayAPI: true
    ingress:
      defaultIngressController: false
      disableIngressClass: false
      nodeNetworkList:
      - networkName: VM Network
    networksConfig:
      nsxtT1LR: /tmp/1109
  serviceEngineGroup: Default-Group
```
aviinfrasetting:
```
apiVersion: ako.vmware.com/v1beta1
kind: AviInfraSetting
metadata:
  creationTimestamp: "2023-11-09T04:03:57Z"
  generation: 1
  name: install-ako-for-nsxt-t1lr-ais
  resourceVersion: "418963"
  uid: 54275bf8-ff86-4565-a047-760f0beaae9b
spec:
  l7Settings:
    shardSize: SMALL
  network:
    vipNetworks:
    - cidr: 10.215.192.0/20
      networkName: VM Network
  nsxSettings:
    t1lr: /tmp/1109
  seGroup:
    name: Default-Group
status:
  error: ""
  status: Accepted 
```
**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.