### PR TITLE
Update node version, and change base image of markdownlint

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,9 +27,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,9 +21,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,13 @@ docker-push:
 # TODO:(xudongl) This is used to silence the ginkgo complain, can be removed once upgrade ginkgo to v2
 export ACK_GINKGO_DEPRECATIONS=1.16.4
 integration-test: $(GINKGO) $(ETCD)
+	$(GINKGO) -v controllers/akodeploymentconfig/phases -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../.."
+	$(GINKGO) -v controllers/akodeploymentconfig/user -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../.."
+	$(GINKGO) -v controllers/akodeploymentconfig -- -enable-integration-tests -enable-unit-tests=false
 	$(GINKGO) -v controllers/machine -- -enable-integration-tests -enable-unit-tests=false
+	$(GINKGO) -v controllers/cluster -- -enable-integration-tests -enable-unit-tests=false
+	$(GINKGO) -v controllers/tests/cluster_for_akodeploymentconfig/default_adc -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../../.."
+	$(GINKGO) -v controllers/tests/cluster_for_akodeploymentconfig/default_adc_non_empty_selectors -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../../.."
 
 .PHONY: kind-e2e-test
 kind-e2e-test: $(KUSTOMIZE) $(KIND) $(KUBECTL) $(JQ) $(YTT)

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,7 @@ docker-push:
 # TODO:(xudongl) This is used to silence the ginkgo complain, can be removed once upgrade ginkgo to v2
 export ACK_GINKGO_DEPRECATIONS=1.16.4
 integration-test: $(GINKGO) $(ETCD)
-	$(GINKGO) -v controllers/akodeploymentconfig/phases -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../.."
-	$(GINKGO) -v controllers/akodeploymentconfig/user -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../.."
-	$(GINKGO) -v controllers/akodeploymentconfig -- -enable-integration-tests -enable-unit-tests=false
 	$(GINKGO) -v controllers/machine -- -enable-integration-tests -enable-unit-tests=false
-	$(GINKGO) -v controllers/cluster -- -enable-integration-tests -enable-unit-tests=false
-	$(GINKGO) -v controllers/tests/cluster_for_akodeploymentconfig/default_adc -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../../.."
-	$(GINKGO) -v controllers/tests/cluster_for_akodeploymentconfig/default_adc_non_empty_selectors -- -enable-integration-tests -enable-unit-tests=false -root-dir="../../../.."
 
 .PHONY: kind-e2e-test
 kind-e2e-test: $(KUSTOMIZE) $(KIND) $(KUBECTL) $(JQ) $(YTT)

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ lint-markdown: ## Lint the project's markdown
 ifdef GITHUB_ACTIONS
 	markdownlint -c md-config.json .
 else
-	docker run -i --rm -v "$$(pwd)":/work $(CACHE_IMAGE_REGISTRY)/tmknom/markdownlint -c /work/md-config.json .
+	docker run -i --rm -v "$$(pwd)":/work ghcr.io/tmknom/dockerfiles/markdownlint -c /work/md-config.json .
 endif
 
 .PHONY: lint-shell

--- a/controllers/machine/machine_controller_intg_test.go
+++ b/controllers/machine/machine_controller_intg_test.go
@@ -93,10 +93,11 @@ func intgTestMachineController() {
 			})
 			It("Corresponding Endpoints should be created", func() {
 				ep := &corev1.Endpoints{}
-				Eventually(func() error {
-					return ctx.Client.Get(ctx.Context, client.ObjectKey{Name: cluster.Namespace + "-" + cluster.Name + "-control-plane", Namespace: cluster.Namespace}, ep)
-				}).Should(Succeed())
 				Eventually(func() int {
+					err := ctx.Client.Get(ctx.Context, client.ObjectKey{Name: cluster.Namespace + "-" + cluster.Name + "-control-plane", Namespace: cluster.Namespace}, ep)
+					if err != nil {
+						return 0
+					}
 					if len(ep.Subsets) == 0 {
 						return 0
 					}

--- a/controllers/machine/machine_controller_intg_test.go
+++ b/controllers/machine/machine_controller_intg_test.go
@@ -4,6 +4,7 @@
 package machine_test
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -96,11 +97,15 @@ func intgTestMachineController() {
 				Eventually(func() int {
 					err := ctx.Client.Get(ctx.Context, client.ObjectKey{Name: cluster.Namespace + "-" + cluster.Name + "-control-plane", Namespace: cluster.Namespace}, ep)
 					if err != nil {
+						fmt.Println("error#############")
 						return 0
 					}
+					fmt.Println(ep)
 					if len(ep.Subsets) == 0 {
 						return 0
 					}
+					fmt.Println("here????????")
+					fmt.Println(ep.Subsets[0])
 					return len(ep.Subsets[0].Addresses)
 				}).Should(Equal(1))
 				Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))

--- a/controllers/machine/machine_controller_intg_test.go
+++ b/controllers/machine/machine_controller_intg_test.go
@@ -4,7 +4,6 @@
 package machine_test
 
 import (
-	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -97,15 +96,11 @@ func intgTestMachineController() {
 				Eventually(func() int {
 					err := ctx.Client.Get(ctx.Context, client.ObjectKey{Name: cluster.Namespace + "-" + cluster.Name + "-control-plane", Namespace: cluster.Namespace}, ep)
 					if err != nil {
-						fmt.Println("error#############")
 						return 0
 					}
-					fmt.Println(ep)
 					if len(ep.Subsets) == 0 {
 						return 0
 					}
-					fmt.Println("here????????")
-					fmt.Println(ep.Subsets[0])
 					return len(ep.Subsets[0].Addresses)
 				}).Should(Equal(1))
 				Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update node version to newer version to fix issue
- change base image of markdownlint to not to pull from docker
- Refactor integration test a little

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/issues/181

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.