### PR TITLE
Add dependabot configuration for main and release-1.10.0 branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,126 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+# #############
+# main branch
+# #############
+# GitHub Actions
+- target-branch: main
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "dependencies"
+# Main Go module
+- target-branch: main
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "dependencies"
+  open-pull-requests-limit: 10
+## Update dockerfile
+- target-branch: main
+  package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "dependencies"
+# Tools Go module
+- target-branch: main
+  package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  labels:
+  - "dependencies"
+
+# ################
+# release branch N
+# ################
+# GitHub Actions
+- target-branch: release-1.10.0
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: ":seedling:[release-1.10.0]"
+  labels:
+  - "dependencies"
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+# Main Go module
+- target-branch: release-1.10.0
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:[release-1.10.0]"
+  labels:
+  - "dependencies"
+  open-pull-requests-limit: 5
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+## Update dockerfile
+- target-branch: release-1.10.0
+  package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ":seedling:[release-1.10.0]"
+  labels:
+  - "dependencies"
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+# Tools Go module
+- target-branch: release-1.10.0
+  package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  commit-message:
+    prefix: ":seedling:[release-1.10.0]"
+  labels:
+  - "dependencies"
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - "dependencies"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add dependabot configuration for main and release-1.10.0 branches

Will update:
- dockerfile
- github actions
- main go module
- tools go module

**Which issue(s) this PR fixes**:

N/A

**Describe testing done for PR**:

N/A

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.