### PR TITLE
Fix go version in workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+env:
+  GO_VERSION: '1.20'
+
 jobs:
   lint:
     name: lint-check
@@ -12,7 +15,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build hack tools for linting
         run: cd hack/tools && make golangci-lint
@@ -42,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
       - name: Build hack tools for unit testing
         run: cd hack/tools && make controller-gen etcd ginkgo kustomize
 
@@ -66,7 +69,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
       - name: Build hack tools for integration testing
         run: cd hack/tools && make controller-gen etcd ginkgo kustomize
       - name: Perform integration tests
@@ -80,7 +83,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
 
       # uncomment this step for debugging: tmate session
 #      - name: Setup tmate session

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,8 @@ on:
       - 'main'
       - 'release-**'
 
+env:
+  GO_VERSION: '1.20'
 
 jobs:
   lint:
@@ -15,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.20' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build hack tools for linting
         run: cd hack/tools && make golangci-lint
@@ -45,7 +47,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: 'true'
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: ${{ env.GO_VERSION }}
       - name: Build hack tools for unit testing
         run: cd hack/tools && make controller-gen etcd ginkgo kustomize
 


### PR DESCRIPTION
**What this PR does / why we need it**:

push workflow was using go 1.19

Also adds a per-workflow env var so we only need to change one line when bumping go

Should fix this failure: https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/actions/runs/8457078160/job/23168248441

**Which issue(s) this PR fixes**:

N/A

**Describe testing done for PR**:

N/A

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.