### PR TITLE
release-1.10.0: Run required actions on all changes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,15 +1,7 @@
 name: Load Balancer Operator for Kubernetes Checks
 on:
   pull_request:
-    paths:
-      - "**/*.go"
-      - "config/**/*"
-      - go.mod
-      - go.sum
-      - "hack/*.sh"
-      - Makefile
-      - ".github/workflows/*.yml"
-      - "codecov.yml"
+    types: [opened, synchronize]
 
 jobs:
   lint:


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously required actions would not run and PRs were not mergeable since they only ran on a subset of files in the repo.

Same as https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/188 but for the release branch

**Which issue(s) this PR fixes**:

N/A

**Describe testing done for PR**:

N/A

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.