### PR TITLE
[1.10.0] Update node version, and change base image of markdownlint (#182)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,9 +26,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,9 +21,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/Dockerfile-for-github-ci
+++ b/Dockerfile-for-github-ci
@@ -11,7 +11,7 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org,direct
 RUN go mod download
 
 # Copy the go source

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ lint-markdown: ## Lint the project's markdown
 ifdef GITHUB_ACTIONS
 	markdownlint -c md-config.json .
 else
-	docker run -i --rm -v "$$(pwd)":/work $(CACHE_IMAGE_REGISTRY)/tmknom/markdownlint -c /work/md-config.json .
+	docker run -i --rm -v "$$(pwd)":/work ghcr.io/tmknom/dockerfiles/markdownlint -c /work/md-config.json .
 endif
 
 .PHONY: lint-shell


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/issues/182
Otherwise the markdownlint job will fail

Also updated dockerfile's GOPROXY


**Which issue(s) this PR fixes**:

Fixes #



**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Cherry pick https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/182

To fix issues inside markdownlint run

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.