### PR TITLE
Fix query parameter encoding for Avi 30.1.1+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9
-	github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea
+	github.com/vmware/alb-sdk v0.0.0-20240502042605-947bfcf176dd
 	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20231012053946-537d99c1eba2
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -82,4 +82,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9 h1:6syWK17nxSy26pyziCVSzd2ugTSqU3b2Rbx5Sx6djNY=
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9/go.mod h1:QiVC4POQPEu3/eNLZOHFrjyRGwWp6AVpZRADBIK1uEc=
-github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea h1:ZcleA18Of+bECNwSMGPmGehqCuaJhq5SXxY6ETP0m6g=
-github.com/vmware/alb-sdk v0.0.0-20230202152455-af9d49bac7ea/go.mod h1:fuRb4saDY/xy/UMeMvyKYmcplNknEL9ysaqYSw7reNE=
+github.com/vmware/alb-sdk v0.0.0-20240502042605-947bfcf176dd h1:90FBuhMMWHNCDwRS+YIIyy21iiK8sayvaE6iPV6gjsc=
+github.com/vmware/alb-sdk v0.0.0-20240502042605-947bfcf176dd/go.mod h1:fuRb4saDY/xy/UMeMvyKYmcplNknEL9ysaqYSw7reNE=
 github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20231012053946-537d99c1eba2 h1:KrokECCnbfSUM0CHUGltyue5RIzBU0UILAxpN06t1Zo=
 github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20231012053946-537d99c1eba2/go.mod h1:BBFHwD7OvIQ+C9+MKwfdwJyJWf/hrYLJj6XiPdjjZqY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -280,4 +280,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-

--- a/pkg/aviclient/client.go
+++ b/pkg/aviclient/client.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -190,7 +191,7 @@ func (r *realAviClient) GetControllerVersion() (string, error) {
 }
 
 func (r *realAviClient) GetObjectByName(obj string, name string, cloudName string, result interface{}, options ...session.ApiOptionsParams) error {
-	uri := "/api/" + obj + "/?include_name&name=" + name + "&cloud_ref.name=" + cloudName
+	uri := "/api/" + obj + "/?include_name&name=" + url.QueryEscape(name) + "&cloud_ref.name=" + url.QueryEscape(cloudName)
 	res, err := r.AviSession.GetCollectionRaw(uri, options...)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses current latest alb-sdk on v30.2.1 branch to consume fix for query encoding rest parameters and fixes local avi client implementation, which is necessary to work with Avi 30.1.1+.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes n/a

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Tested on a local cluster with Avi 30.1.1 and the webhook at least works. Didn't have a full cluster-api setup to test further than that. Although it github PR e2e tests pass it should be fine.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Fix parameter's query encoding issue when making rest requests to Avi controller 30.1.1+
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.