### PR TITLE
Fix flaky integration test by adding one more check

### DIFF
--- a/controllers/cluster/cluster_intg_test.go
+++ b/controllers/cluster/cluster_intg_test.go
@@ -153,6 +153,9 @@ func intgTestEnsureClusterHAProvider() {
 						if err != nil {
 							return false
 						}
+						if len(service.Status.LoadBalancer.Ingress) == 0 {
+							return false
+						}
 						if service.Status.LoadBalancer.Ingress[0].IP != "10.1.2.1" {
 							return false
 						}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add check of lb.ingress length. In case it will fail like this 
https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/actions/runs/8930964320/job/24532158192?pr=237

```
•! Panic [1.013 seconds]
Integration tests
/home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/pkg/test/builder/test_suite.go:153
  ClusterController Test
  /home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/controllers/cluster/suite_test.go:68
    EnsureHAService
    /home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/controllers/cluster/cluster_intg_test.go:26
      when Avi is HA provider
      /home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/controllers/cluster/cluster_intg_test.go:73
        when FQDN HA service endpoint exist
        /home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/controllers/cluster/cluster_intg_test.go:109
          should create service and endpoint when FQDN is resolved [It]
          /home/runner/work/load-balancer-operator-for-kubernetes/load-balancer-operator-for-kubernetes/controllers/cluster/cluster_intg_test.go:134

          Test Panicked
          runtime error: index out of range [0] with length 0
          /home/runner/go/pkg/mod/github.com/onsi/gomega@v1.33.0/internal/async_assertion.go:321

          Full Stack Trace
          github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3.1()
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.