### PR TITLE
[release-1.11.0] Update node version, and change base image of markdownlint (#182)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,9 +27,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,9 +21,9 @@ jobs:
         run: cd hack/tools && make golangci-lint
 
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install markdown-lint tool
         run: npm install -g markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ lint-markdown: ## Lint the project's markdown
 ifdef GITHUB_ACTIONS
 	markdownlint -c md-config.json .
 else
-	docker run -i --rm -v "$$(pwd)":/work $(CACHE_IMAGE_REGISTRY)/tmknom/markdownlint -c /work/md-config.json .
+	docker run -i --rm -v "$$(pwd)":/work ghcr.io/tmknom/dockerfiles/markdownlint -c /work/md-config.json .
 endif
 
 .PHONY: lint-shell

--- a/controllers/machine/machine_controller_intg_test.go
+++ b/controllers/machine/machine_controller_intg_test.go
@@ -93,13 +93,16 @@ func intgTestMachineController() {
 			})
 			It("Corresponding Endpoints should be created", func() {
 				ep := &corev1.Endpoints{}
-				Eventually(func() bool {
+				Eventually(func() int {
 					err := ctx.Client.Get(ctx.Context, client.ObjectKey{Name: cluster.Namespace + "-" + cluster.Name + "-control-plane", Namespace: cluster.Namespace}, ep)
-					return err == nil
-				}).Should(BeTrue())
-				Expect(ep.Subsets).ShouldNot(BeNil())
-				Expect(ep.Subsets[0].Addresses).ShouldNot(BeNil())
-				Expect(len(ep.Subsets[0].Addresses)).Should(Equal(1))
+					if err != nil {
+						return 0
+					}
+					if len(ep.Subsets) == 0 {
+						return 0
+					}
+					return len(ep.Subsets[0].Addresses)
+				}).Should(Equal(1))
 				Expect(ep.Subsets[0].Addresses[0].IP).Should(Equal("1.1.1.1"))
 			})
 			It("Should add one more machine", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick of #182 on release-1.11.0 branch to fix markdown lint github action.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.