### PR TITLE
Add dependabot for release 1.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,13 +56,13 @@ updates:
 # release branch N
 # ################
 # GitHub Actions
-- target-branch: release-1.11.0
+- target-branch: release-1.12
   package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
   commit-message:
-    prefix: ":seedling:[release-1.11.0]"
+    prefix: ":seedling:[release-1.12]"
   labels:
   - "dependencies"
   ignore:
@@ -71,7 +71,7 @@ updates:
     - "version-update:semver-major"
     - "version-update:semver-minor"
 # Main Go module
-- target-branch: release-1.11.0
+- target-branch: release-1.12
   package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -82,7 +82,7 @@ updates:
     kubernetes:
       patterns: [ "k8s.io/*" ]
   commit-message:
-    prefix: ":seedling:[release-1.11.0]"
+    prefix: ":seedling:[release-1.12]"
   labels:
   - "dependencies"
   open-pull-requests-limit: 5
@@ -92,13 +92,13 @@ updates:
     - "version-update:semver-major"
     - "version-update:semver-minor"
 ## Update dockerfile
-- target-branch: release-1.11.0
+- target-branch: release-1.12
   package-ecosystem: docker
   directory: "/"
   schedule:
     interval: weekly
   commit-message:
-    prefix: ":seedling:[release-1.11.0]"
+    prefix: ":seedling:[release-1.12]"
   labels:
   - "dependencies"
   ignore:
@@ -107,86 +107,14 @@ updates:
     - "version-update:semver-major"
     - "version-update:semver-minor"
 # Tools Go module
-- target-branch: release-1.11.0
+- target-branch: release-1.12
   package-ecosystem: "gomod"
   directory: "/hack/tools"
   schedule:
     interval: "weekly"
     day: "tuesday"
   commit-message:
-    prefix: ":seedling:[release-1.11.0]"
-  labels:
-  - "dependencies"
-  ignore:
-  - dependency-name: "*"
-    update-types:
-    - "version-update:semver-major"
-    - "version-update:semver-minor"
-  labels:
-  - "dependencies"
-# ##################
-# release branch N-1
-# ##################
-# GitHub Actions
-- target-branch: release-1.10.0
-  package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  commit-message:
-    prefix: ":seedling:[release-1.10.0]"
-  labels:
-  - "dependencies"
-  ignore:
-  - dependency-name: "*"
-    update-types:
-    - "version-update:semver-major"
-    - "version-update:semver-minor"
-# Main Go module
-- target-branch: release-1.10.0
-  package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  commit-message:
-    prefix: ":seedling:[release-1.10.0]"
-  labels:
-  - "dependencies"
-  open-pull-requests-limit: 5
-  ignore:
-  - dependency-name: "*"
-    update-types:
-    - "version-update:semver-major"
-    - "version-update:semver-minor"
-## Update dockerfile
-- target-branch: release-1.10.0
-  package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: ":seedling:[release-1.10.0]"
-  labels:
-  - "dependencies"
-  ignore:
-  - dependency-name: "*"
-    update-types:
-    - "version-update:semver-major"
-    - "version-update:semver-minor"
-# Tools Go module
-- target-branch: release-1.10.0
-  package-ecosystem: "gomod"
-  directory: "/hack/tools"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  commit-message:
-    prefix: ":seedling:[release-1.10.0]"
+    prefix: ":seedling:[release-1.12]"
   labels:
   - "dependencies"
   ignore:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds dependabot for the release-1.12 branch, it also removes the dependabot config for older releases.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.