### PR TITLE
Update kustomize-to-ytt so that it contains all manifest except the ako-operator deployment

### DIFF
--- a/config/kustomize-to-ytt/kustomization.yaml
+++ b/config/kustomize-to-ytt/kustomization.yaml
@@ -13,5 +13,45 @@ commonLabels:
   app: tanzu-ako-operator
 
 bases:
-  - ../crd
-  - ../rbac
+- ../crd
+- ../rbac
+- ../webhook
+- ../certmanager
+
+
+patchesStrategicMerge:
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+  - webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/kustomize-to-ytt/webhookcainjection_patch.yaml
+++ b/config/kustomize-to-ytt/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -8,5 +8,3 @@ spec:
   ports:
     - port: 443
       targetPort: 9443
-  selector:
-    control-plane: controller-manager

--- a/config/ytt/ako-operator.yaml
+++ b/config/ytt/ako-operator.yaml
@@ -29,16 +29,6 @@ spec:
     spec:
       containers:
         - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-        - args:
             - --metrics-addr=127.0.0.1:8080
           command:
             - /manager

--- a/config/ytt/static.yaml
+++ b/config/ytt/static.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: tkg-system-networking/ako-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     app: tanzu-ako-operator
@@ -798,3 +798,106 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: tkg-system-networking
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-webhook-service
+  namespace: tkg-system-networking
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: tanzu-ako-operator
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-serving-cert
+  namespace: tkg-system-networking
+spec:
+  dnsNames:
+  - ako-operator-webhook-service.tkg-system-networking.svc
+  - ako-operator-webhook-service.tkg-system-networking.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: ako-operator-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-selfsigned-issuer
+  namespace: tkg-system-networking
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: tkg-system-networking/ako-operator-serving-cert
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: ako-operator-webhook-service
+      namespace: tkg-system-networking
+      path: /validate-networking-tkg-tanzu-vmware-com-v1alpha1-akodeploymentconfig
+  failurePolicy: Fail
+  name: vakodeploymentconfig.kb.io
+  rules:
+  - apiGroups:
+    - networking.tkg.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - akodeploymentconfigs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: tkg-system-networking/ako-operator-serving-cert
+  labels:
+    app: tanzu-ako-operator
+  name: ako-operator-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: ako-operator-webhook-service
+      namespace: tkg-system-networking
+      path: /validate-networking-tkg-tanzu-vmware-com-v1alpha1-akodeploymentconfig
+  failurePolicy: Fail
+  name: vakodeploymentconfig.kb.io
+  rules:
+  - apiGroups:
+    - networking.tkg.tanzu.vmware.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - akodeploymentconfigs
+  sideEffects: None


### PR DESCRIPTION
**What this PR does / why we need it**:
The static.yaml should container everything excluding the ako-deployment manifest.

* This PR fixes `config/kustomize-to-ytt/kustomization.yaml` to include correct files
* Remove unnecessary label from `config/webhook/service.yaml`
* Remove kube-rback-proxy from `config/ytt/ako-operator.yaml` since it's not used anymore
* Add back webhook change `config/ytt/static.yaml`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.