### PR TITLE
handle missing/extra permissions in role sync

### DIFF
--- a/controllers/akodeploymentconfig/user/ako_role_test.go
+++ b/controllers/akodeploymentconfig/user/ako_role_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package user
+
+import (
+	"testing"
+)
+
+func TestRolePermissionAndMapMatch(t *testing.T) {
+	if len(AkoRolePermission) != len(AkoRolePermissionMap) {
+		t.Errorf("len(AkoRolePermission) == %d, len(AkoRolePermissionMap) == %d", len(AkoRolePermission), len(AkoRolePermissionMap))
+	}
+
+	allMatch := true
+	for _, permission := range AkoRolePermission {
+		if *permission.Type != AkoRolePermissionMap[*permission.Resource] {
+			allMatch = false
+			t.Logf("AkoRolePermission[%s] == %s, AkoRolePermissionMap[%s] == %s", *permission.Resource, *permission.Type, *permission.Resource, AkoRolePermissionMap[*permission.Resource])
+		}
+	}
+
+	if !allMatch {
+		t.Error("Not all entries in AkoRolePermission and AkoRolePermissionMap match")
+	}
+}

--- a/controllers/akodeploymentconfig/user/suite_test.go
+++ b/controllers/akodeploymentconfig/user/suite_test.go
@@ -54,4 +54,5 @@ func intgTests() {
 }
 
 func unitTests() {
+	Describe("AKO user reconciler unit tests", SyncAkoUserRoleTest)
 }

--- a/controllers/akodeploymentconfig/user/user_controller.go
+++ b/controllers/akodeploymentconfig/user/user_controller.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -35,11 +36,14 @@ type AkoUserReconciler struct {
 func NewProvider(client client.Client,
 	aviClient aviclient.Client,
 	logger logr.Logger,
-	scheme *runtime.Scheme) *AkoUserReconciler {
-	return &AkoUserReconciler{Client: client,
+	scheme *runtime.Scheme,
+) *AkoUserReconciler {
+	return &AkoUserReconciler{
+		Client:    client,
 		aviClient: aviClient,
 		Log:       logger,
-		Scheme:    scheme}
+		Scheme:    scheme,
+	}
 }
 
 // ReconcileAviUser reconcile akodeploymentconfig clusters' avi user
@@ -306,7 +310,7 @@ func (r *AkoUserReconciler) createOrUpdateAviUser(aviUsername, aviPassword, tena
 // getOrCreateAkoUserRole get ako user's role, create one if not exist
 func (r *AkoUserReconciler) getOrCreateAkoUserRole(roleTenantRef *string) (*models.Role, error) {
 	role, err := r.aviClient.RoleGetByName(akoov1alpha1.AkoUserRoleName)
-	//not found ako user role, create one
+	// not found ako user role, create one
 	if aviclient.IsAviRoleNonExistentError(err) {
 		role = &models.Role{
 			Name:       ptr.To(akoov1alpha1.AkoUserRoleName),
@@ -327,18 +331,55 @@ func (r *AkoUserReconciler) ensureAkoUserRole() (*models.Role, error) {
 	if err != nil {
 		return role, err
 	}
-	// check if role needs to be sync
-	needSync := false
-	for i, permission := range role.Privileges {
-		if AkoRolePermissionMap[*permission.Resource] != *permission.Type {
-			needSync = true
-			role.Privileges[i].Type = ptr.To(AkoRolePermissionMap[*permission.Resource])
-		}
-	}
-	if needSync {
+
+	// check if role needs to be synced
+	if syncAkoUserRole(role) {
 		return r.aviClient.RoleUpdate(role)
 	}
+
 	return role, nil
+}
+
+// syncAkoUserRole checks the Role for the complete/correct
+// set of permissions and makes any additions/updates necessary.
+// Any additional permissions on the Role that are not part of
+// the desired AKO role are left as-is. It returns a bool
+// indicating whether the Role was changed.
+func syncAkoUserRole(role *models.Role) bool {
+	existingResources := sets.NewString()
+	updated := false
+
+	for i, permission := range role.Privileges {
+		desiredType, ok := AkoRolePermissionMap[*permission.Resource]
+		if !ok {
+			// Existing AVI role has a permission that's not part of
+			// the desired AKO role: leave it as-is.
+			continue
+		}
+
+		existingResources.Insert(*permission.Resource)
+
+		if *permission.Type != desiredType {
+			// Existing AVI role has a permission that's part of the
+			// desired AKO role, but has the wrong type: update it.
+			role.Privileges[i].Type = ptr.To(desiredType)
+			updated = true
+		}
+	}
+
+	for resource, desiredType := range AkoRolePermissionMap {
+		if !existingResources.Has(resource) {
+			// Existing AVI role is missing a permission that's
+			// part of the desired AKO role: add it.
+			role.Privileges = append(role.Privileges, &models.Permission{
+				Resource: ptr.To(resource),
+				Type:     ptr.To(desiredType),
+			})
+			updated = true
+		}
+	}
+
+	return updated
 }
 
 // mcAVISecretNameNameSpace get avi user secret name/namespace in management cluster. There is no need to
@@ -371,7 +412,6 @@ func (r *AkoUserReconciler) createAviUserSecret(name, namespace, username, passw
 				APIVersion:         akoov1alpha1.AkoDeploymentConfigVersion,
 			},
 		}
-
 	}
 	secret.Data["username"] = []byte(username)
 	secret.Data["password"] = []byte(password)

--- a/controllers/akodeploymentconfig/user/user_controller.go
+++ b/controllers/akodeploymentconfig/user/user_controller.go
@@ -346,7 +346,7 @@ func (r *AkoUserReconciler) ensureAkoUserRole() (*models.Role, error) {
 // the desired AKO role are left as-is. It returns a bool
 // indicating whether the Role was changed.
 func syncAkoUserRole(role *models.Role) bool {
-	existingResources := sets.NewString()
+	existingResources := sets.New[string]()
 	updated := false
 
 	for i, permission := range role.Privileges {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the AKO user role sync logic to properly
handle missing or extra permissions in the role
in AVI controller by adding missing permissions
and allowing extra permissions to remain on the
role.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Added unit tests

**Special notes for your reviewer**:
cc @lubronzhan 

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Updates the AKO user role sync logic to properly handle missing or extra permissions in the role in AVI controller by adding missing permissions and allowing extra permissions to remain on the role.
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.