### PR TITLE
bump golangci-lint to v1.59.0

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -64,7 +64,7 @@ $(CONTROLLER_GEN):
 golangci-lint: $(GOLANGCI_LINT) $(SRCS)
 golangci-lint: ## Build golangci-lint
 $(GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.54.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.0
 
 kustomize: $(KUSTOMIZE) $(SRCS)
 kustomize: ## Build kustomize


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golangci-lint to v1.59.0 to get support for new Go 1.22 language features.

**Which issue(s) this PR fixes**:

**Describe testing done for PR**:

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.