### PR TITLE
[release-1.12 cherrypick] handle missing/extra permissions in role sync

### DIFF
--- a/controllers/akodeploymentconfig/user/ako_role_test.go
+++ b/controllers/akodeploymentconfig/user/ako_role_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package user
+
+import (
+	"testing"
+)
+
+func TestRolePermissionAndMapMatch(t *testing.T) {
+	if len(AkoRolePermission) != len(AkoRolePermissionMap) {
+		t.Errorf("len(AkoRolePermission) == %d, len(AkoRolePermissionMap) == %d", len(AkoRolePermission), len(AkoRolePermissionMap))
+	}
+
+	allMatch := true
+	for _, permission := range AkoRolePermission {
+		if *permission.Type != AkoRolePermissionMap[*permission.Resource] {
+			allMatch = false
+			t.Logf("AkoRolePermission[%s] == %s, AkoRolePermissionMap[%s] == %s", *permission.Resource, *permission.Type, *permission.Resource, AkoRolePermissionMap[*permission.Resource])
+		}
+	}
+
+	if !allMatch {
+		t.Error("Not all entries in AkoRolePermission and AkoRolePermissionMap match")
+	}
+}

--- a/controllers/akodeploymentconfig/user/suite_test.go
+++ b/controllers/akodeploymentconfig/user/suite_test.go
@@ -54,4 +54,5 @@ func intgTests() {
 }
 
 func unitTests() {
+	Describe("AKO user reconciler unit tests", SyncAkoUserRoleTest)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the AKO user role sync logic to properly
handle missing or extra permissions in the role
in AVI controller by adding missing permissions
and allowing extra permissions to remain on the
role.

Cherry-pick of #287.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Updates the AKO user role sync logic to properly
handle missing or extra permissions in the role
in AVI controller by adding missing permissions
and allowing extra permissions to remain on the
role.
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.