### PR TITLE
Trigger adc reconciliation if credentials is updated in ADC

### DIFF
--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller.go
@@ -182,9 +182,12 @@ func (r *AKODeploymentConfigReconciler) secretToAKODeploymentConfig(c client.Cli
 		}
 
 		var requests []ctrl.Request
+		// enqueue if credentials or certificate of akoo is updated
 		for _, akoDeploymentConfig := range akoDeploymentConfigs.Items {
 			if akoDeploymentConfig.Spec.CertificateAuthorityRef.Name == secret.Name &&
-				akoDeploymentConfig.Spec.CertificateAuthorityRef.Namespace == secret.Namespace {
+				akoDeploymentConfig.Spec.CertificateAuthorityRef.Namespace == secret.Namespace ||
+				akoDeploymentConfig.Spec.AdminCredentialRef.Name == secret.Name &&
+					akoDeploymentConfig.Spec.AdminCredentialRef.Namespace == secret.Namespace {
 				requests = append(requests, ctrl.Request{
 					NamespacedName: types.NamespacedName{
 						Namespace: akoDeploymentConfig.Namespace,

--- a/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
+++ b/controllers/akodeploymentconfig/akodeploymentconfig_controller_intg_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako"
 	ako_operator "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako-operator"
 	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/test/builder"
-	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/test/util"
 	testutil "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/test/util"
 )
 
@@ -352,7 +351,7 @@ func intgTestAkoDeploymentConfigController() {
 			err := os.Setenv(ako_operator.IsControlPlaneHAProvider, "False")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-		It("shouldn't wait AIS if controlplane and dataplane has the same CIDR", func() {
+		It("shouldn't wait for AIS if controlplane and dataplane has the same CIDR", func() {
 			akoDeploymentConfig.Spec.ControlPlaneNetwork.CIDR = akoDeploymentConfig.Spec.DataNetwork.CIDR
 			createObjects(akoDeploymentConfig, cluster, controllerCredentials, controllerCA)
 			aviInfraSettingName = akoDeploymentConfig.Name + "-ais"
@@ -369,7 +368,7 @@ func intgTestAkoDeploymentConfigController() {
 			Expect(service.Annotations[akoov1alpha1.HAAVIInfraSettingAnnotationsKey]).To(BeEmpty())
 
 		})
-		It("should wait AIS before adding annotation to service", func() {
+		It("should wait for AIS before adding annotation to service", func() {
 			createObjects(akoDeploymentConfig, cluster, controllerCredentials, controllerCA)
 			aviInfraSettingName = akoDeploymentConfig.Name + "-ais"
 			ensureRuntimeObjectMatchExpectation(client.ObjectKey{
@@ -756,7 +755,7 @@ func intgTestAkoDeploymentConfigController() {
 						}, &akoov1alpha1.AKODeploymentConfig{}, true)
 
 						ensureRuntimeObjectMatchExpectation(client.ObjectKey{
-							Name: util.CustomADCName,
+							Name: testutil.CustomADCName,
 						}, &akoov1alpha1.AKODeploymentConfig{}, true)
 					})
 
@@ -775,7 +774,7 @@ func intgTestAkoDeploymentConfigController() {
 						ensureClusterAviLabelValueMatchExpectation(client.ObjectKey{
 							Name:      cluster.Name,
 							Namespace: cluster.Namespace,
-						}, akoov1alpha1.AviClusterLabel, util.CustomADCName, true)
+						}, akoov1alpha1.AviClusterLabel, testutil.CustomADCName, true)
 
 						By("removing cluster's label")
 						latestCluster := &clusterv1.Cluster{
@@ -814,7 +813,7 @@ func intgTestAkoDeploymentConfigController() {
 						}, &akoov1alpha1.AKODeploymentConfig{}, true)
 
 						ensureRuntimeObjectMatchExpectation(client.ObjectKey{
-							Name: util.CustomADCName,
+							Name: testutil.CustomADCName,
 						}, &akoov1alpha1.AKODeploymentConfig{}, true)
 					})
 
@@ -833,7 +832,7 @@ func intgTestAkoDeploymentConfigController() {
 						ensureClusterAviLabelValueMatchExpectation(client.ObjectKey{
 							Name:      cluster.Name,
 							Namespace: cluster.Namespace,
-						}, akoov1alpha1.AviClusterLabel, util.CustomADCName, true)
+						}, akoov1alpha1.AviClusterLabel, testutil.CustomADCName, true)
 
 						By("removing cluster's label")
 						latestCluster := &clusterv1.Cluster{

--- a/controllers/akodeploymentconfig/cluster/cluster_controller.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller.go
@@ -8,24 +8,24 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	akoov1alpha1 "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako"
-	akoo "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako-operator"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	akoov1alpha1 "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/api/v1alpha1"
+	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako"
+	akoo "github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/ako-operator"
+	"github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pkg/utils"
 )
 
 const (
@@ -122,7 +122,7 @@ func (r *ClusterReconciler) cleanup(
 	//   - secret is <cluster-name>-load-balancer-and-ingress-service-data-values
 	secretName := r.akoAddonDataValueName()
 	if akoo.IsClusterClassBasedCluster(obj) {
-		secretName = r.akoAddonSecretNameForClusterClass(obj)
+		secretName = utils.AKOAddonSecretNameForClusterClass(obj)
 	}
 	if err := remoteClient.Get(ctx, client.ObjectKey{
 		Name:      secretName,

--- a/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
+++ b/controllers/akodeploymentconfig/cluster/cluster_controller_addon_secret.go
@@ -87,7 +87,7 @@ func (r *ClusterReconciler) ReconcileAddonSecret(
 	}
 	secret := &corev1.Secret{}
 	if err = r.Get(ctx, client.ObjectKey{
-		Name:      r.akoAddonSecretName(cluster),
+		Name:      utils.AKOAddonSecretName(cluster),
 		Namespace: cluster.Namespace,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -125,7 +125,7 @@ func (r *ClusterReconciler) ReconcileAddonSecretDelete(
 
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, client.ObjectKey{
-		Name:      r.akoAddonSecretName(cluster),
+		Name:      utils.AKOAddonSecretName(cluster),
 		Namespace: cluster.Namespace,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -153,18 +153,6 @@ func (r *ClusterReconciler) ReconcileAddonSecretDelete(
 	return res, nil
 }
 
-func (r *ClusterReconciler) aviUserSecretName(cluster *clusterv1.Cluster) string {
-	return cluster.Name + "-avi-credentials"
-}
-
-func (r *ClusterReconciler) akoAddonSecretName(cluster *clusterv1.Cluster) string {
-	return cluster.Name + "-load-balancer-and-ingress-service-addon"
-}
-
-func (r *ClusterReconciler) akoAddonSecretNameForClusterClass(cluster *clusterv1.Cluster) string {
-	return cluster.Name + "-load-balancer-and-ingress-service-data-values"
-}
-
 func (r *ClusterReconciler) createAKOAddonSecret(cluster *clusterv1.Cluster, obj *akoov1alpha1.AKODeploymentConfig, aviUsersecret *corev1.Secret) (*corev1.Secret, error) {
 	secretStringData, err := AkoAddonSecretDataYaml(cluster, obj, aviUsersecret)
 	if err != nil {
@@ -172,7 +160,7 @@ func (r *ClusterReconciler) createAKOAddonSecret(cluster *clusterv1.Cluster, obj
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.akoAddonSecretName(cluster),
+			Name:      utils.AKOAddonSecretName(cluster),
 			Namespace: cluster.Namespace,
 			Annotations: map[string]string{
 				akoov1alpha1.TKGAddonAnnotationKey: "networking/load-balancer-and-ingress-service",
@@ -223,7 +211,7 @@ func AkoAddonSecretDataYaml(cluster *clusterv1.Cluster, obj *akoov1alpha1.AKODep
 func (r *ClusterReconciler) getClusterAviUserSecret(cluster *clusterv1.Cluster, ctx context.Context) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, client.ObjectKey{
-		Name:      r.aviUserSecretName(cluster),
+		Name:      utils.AVIUserSecretName(cluster),
 		Namespace: cluster.Namespace,
 	}, secret); err != nil {
 		return secret, err
@@ -264,7 +252,7 @@ func (r *ClusterReconciler) patchAkoPackageRefToClusterBootstrap(ctx context.Con
 	expectedAKOClusterBootstrapPackage := &runv1alpha3.ClusterBootstrapPackage{
 		RefName: akoPackageRefName,
 		ValuesFrom: &runv1alpha3.ValuesFrom{
-			SecretRef: r.akoAddonSecretName(cluster),
+			SecretRef: utils.AKOAddonSecretName(cluster),
 		},
 	}
 
@@ -390,7 +378,7 @@ func ValidateClusterIpFamily(cluster *clusterv1.Cluster, adc *akoov1alpha1.AKODe
 	// When enable avi as control plane ha, backend server shouldn't use secondary ip type
 	// TODO:(chenlin) Remove validation after AKO supports configurable ip pool
 	if isVIPProvider && adcIpFamily == IPv6IpFamily && clusterIpFamily == DualStackIPv4Primary {
-		return errors.New("When enabling avi as control plane HA, AKO with IP family V6 can not work together with ipv4 primary dual-stack cluster")
+		return errors.New("when enabling avi as control plane HA, AKO with IP family V6 can not work together with ipv4 primary dual-stack cluster")
 	}
 	return nil
 }

--- a/pkg/haprovider/haprovider.go
+++ b/pkg/haprovider/haprovider.go
@@ -67,7 +67,7 @@ func (r *HAProvider) CreateOrUpdateHAService(ctx context.Context, cluster *clust
 		Namespace: cluster.Namespace,
 	}, service); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.log.Info(serviceName + "service doesn't exist, start creating it...")
+			r.log.Info(serviceName + " service doesn't exist, start creating it...")
 			service, err = r.createService(ctx, cluster)
 			if err != nil {
 				return err

--- a/pkg/utils/get_objects.go
+++ b/pkg/utils/get_objects.go
@@ -1,0 +1,20 @@
+// Copyright 2024 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func AVIUserSecretName(cluster *clusterv1.Cluster) string {
+	return cluster.Name + "-avi-credentials"
+}
+
+func AKOAddonSecretName(cluster *clusterv1.Cluster) string {
+	return cluster.Name + "-load-balancer-and-ingress-service-addon"
+}
+
+func AKOAddonSecretNameForClusterClass(cluster *clusterv1.Cluster) string {
+	return cluster.Name + "-load-balancer-and-ingress-service-data-values"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Refactor some code.
* Also enqueue credential secret update events to ADC updates queue

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/issues/309

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.