### PR TITLE
Change trivy scan from 1.10.0 release branch to 1.12

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         branch:
         - main
-        - release-1.10.0
+        - release-1.12
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates Trivy scan action to run against release-1.12 branch instead of now unsupported 1.10.0 release branch

**Which issue(s) this PR fixes**:
N/A

**Describe testing done for PR**:
N/A

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.