### PR TITLE
[1.12][TKG-29306] Filter user permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.22-bullseye AS builder
+ARG GOLANG_IMAGE=golang:1.23-bullseye
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+FROM $GOLANG_IMAGE AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -10,7 +12,9 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-ENV GOPROXY=https://goproxy.io,direct
+ARG GOPROXY=https://goproxy.io,direct
+
+ENV GOPROXY=$GOPROXY
 RUN go mod download
 
 # Copy the go source
@@ -24,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM $BASE_IMAGE
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ IMG ?= ako-operator:$(IMAGE_TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 
+GOPROXY ?= https://goproxy.io,direct
+
 # downstream cache to avoid docker pull limitation
 CACHE_IMAGE_REGISTRY ?= harbor-repo.vmware.com/dockerhub-proxy-cache
 
@@ -78,7 +80,11 @@ generate: $(CONTROLLER_GEN)
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG} -f Dockerfile
+	docker build . -t ${IMG} \
+		--build-arg GOPROXY=$(GOPROXY) \
+		--build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		-f Dockerfile
 
 # Push the docker image
 docker-push:

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -55,4 +55,6 @@ const (
 	HAAVIInfraSettingAnnotationsKey    = "aviinfrasetting.ako.vmware.com/name"
 
 	AKODeploymentConfigControllerName = "akodeploymentconfig-controller"
+
+	AVIControllerEnterpriseOnlyVersion = "v30.0.0"
 )

--- a/controllers/akodeploymentconfig/user/ako_role.go
+++ b/controllers/akodeploymentconfig/user/ako_role.go
@@ -4,7 +4,9 @@
 package user
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/vmware/alb-sdk/go/models"
+	"golang.org/x/mod/semver"
 	"k8s.io/utils/ptr"
 )
 
@@ -319,4 +321,23 @@ var AkoRolePermission = []*models.Permission{
 		Type:     ptr.To("WRITE_ACCESS"),
 		Resource: ptr.To("PERMISSION_L4POLICYSET"),
 	},
+}
+
+var deprecatePermissionMap = map[string]string{
+	"PERMISSION_PINGACCESSAGENT": "v30.2.1",
+}
+
+func filterAkoRolePermissionByVersion(log logr.Logger, permissions []*models.Permission, version string) []*models.Permission {
+	filtered := []*models.Permission{}
+	for _, permission := range permissions {
+		if v, ok := deprecatePermissionMap[*permission.Resource]; ok && semver.Compare(version, v) >= 0 {
+			log.Info("Skip deprecated permission", "permission", *permission.Resource)
+			// Skip deprecated permission
+			continue
+		}
+
+		filtered = append(filtered, permission)
+
+	}
+	return filtered
 }

--- a/controllers/akodeploymentconfig/user/user_controller_test.go
+++ b/controllers/akodeploymentconfig/user/user_controller_test.go
@@ -139,7 +139,7 @@ func SyncAkoUserRoleTest() {
 	Specify("role has no permissions", func() {
 		role := &models.Role{}
 
-		updated := syncAkoUserRole(role)
+		updated := syncAkoUserRole(role, "v20.0.0")
 		Expect(updated).To(BeTrue())
 		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission)))
 		Expect(role.Privileges).To(ContainElements(AkoRolePermission))
@@ -159,7 +159,7 @@ func SyncAkoUserRoleTest() {
 			}
 		}
 
-		updated := syncAkoUserRole(role)
+		updated := syncAkoUserRole(role, "v20.0.0")
 		Expect(updated).To(BeTrue())
 		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission)))
 		Expect(role.Privileges).To(ContainElements(AkoRolePermission))
@@ -179,7 +179,7 @@ func SyncAkoUserRoleTest() {
 			})
 		}
 
-		updated := syncAkoUserRole(role)
+		updated := syncAkoUserRole(role, "v20.0.0")
 		Expect(updated).To(BeTrue())
 		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission)))
 		Expect(role.Privileges).To(ContainElements(AkoRolePermission))
@@ -208,7 +208,7 @@ func SyncAkoUserRoleTest() {
 			role.Privileges[i], role.Privileges[j] = role.Privileges[j], role.Privileges[i]
 		})
 
-		updated := syncAkoUserRole(role)
+		updated := syncAkoUserRole(role, "v20.0.0")
 		Expect(updated).To(BeFalse())
 		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission) + len(additionalPrivileges)))
 		Expect(role.Privileges).To(ContainElements(AkoRolePermission))
@@ -246,10 +246,27 @@ func SyncAkoUserRoleTest() {
 			role.Privileges[i], role.Privileges[j] = role.Privileges[j], role.Privileges[i]
 		})
 
-		updated := syncAkoUserRole(role)
+		updated := syncAkoUserRole(role, "v20.0.0")
 		Expect(updated).To(BeTrue())
 		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission) + len(additionalPrivileges)))
 		Expect(role.Privileges).To(ContainElements(AkoRolePermission))
 		Expect(role.Privileges).To(ContainElements(additionalPrivileges))
+	})
+
+	Specify("AVI Controller is higher than 30.2.1", func() {
+		role := &models.Role{}
+
+		updated := syncAkoUserRole(role, "v30.2.1")
+		newPermissions := []*models.Permission{}
+		for _, permission := range AkoRolePermission {
+			if *permission.Resource == "PERMISSION_PINGACCESSAGENT" {
+				continue
+			}
+			newPermissions = append(newPermissions, permission)
+
+		}
+		Expect(updated).To(BeTrue())
+		Expect(role.Privileges).To(HaveLen(len(AkoRolePermission) - 1))
+		Expect(role.Privileges).To(ContainElements(newPermissions))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221104044415-a462bbe793b9
 	github.com/vmware/alb-sdk v0.0.0-20240502042605-947bfcf176dd
 	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes v0.0.0-20231012053946-537d99c1eba2
+	golang.org/x/mod v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.6
 	k8s.io/apiextensions-apiserver v0.29.6

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjs
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/pull/369/commits

Filter permissions, remove the one that's been deprecated in corresponding AVI Controller version
Add username to user object if it's enterprise license
More logging
Refactor makefile and dockerfile

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [labels](https://github.com/vmware-tanzu/load-balancer-operator-for-kubernetes/labels) according to what type of issue is being addressed.